### PR TITLE
feat: add npm publish workflow on release published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,10 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: npm run build --if-present
 
       - name: Run checks
         run: npm run check
 
       - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
- Triggers on GitHub release published event (set by release-please)
- Runs full build and check suite before publishing
- Uses npm provenance (id-token: write) for supply chain attestation
- Requires NPM_TOKEN secret in repository settings
- Actions pinned to exact SHAs with version comments