### PR TITLE
feat: add turn, bash, compact, and model observation hooks

### DIFF
--- a/src/cli/analyze-prompt.ts
+++ b/src/cli/analyze-prompt.ts
@@ -30,6 +30,26 @@ Analyze observations for these categories:
 - Actions that consistently lead to errors or user corrections
 - Trigger: the bad pattern situation; Action: what to do instead
 
+### Turn Structure
+- turn_start/turn_end events group tool calls into LLM response cycles
+- Look for recurring tool sequences within turns (e.g. grep→read→edit)
+- tool_count and error_count on turn_end summarize the turn
+- High error_count turns suggest inefficient approaches
+
+### Context Pressure
+- session_compact events signal context window pressure
+- Frequent compaction correlated with specific tool patterns may indicate waste
+- tokens_used on turn_end and agent_end tracks token consumption
+
+### User Shell Commands
+- user_bash events capture manual shell commands the user runs
+- Repeated commands after agent actions reveal verification patterns
+- These are behaviors the agent should learn to do proactively
+
+### Model Preferences
+- model_select events track when users switch models
+- Patterns in model switching reveal task-complexity preferences
+
 ## Feedback Analysis
 
 Each observation may include an active_instincts field listing instinct IDs

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,8 +34,8 @@ describe("extension entry point - registrations", () => {
     expect(typeof extension).toBe("function");
   });
 
-  it("registers exactly 7 event handlers", () => {
-    expect(vi.mocked(pi.on)).toHaveBeenCalledTimes(7);
+  it("registers exactly 12 event handlers", () => {
+    expect(vi.mocked(pi.on)).toHaveBeenCalledTimes(12);
   });
 
   it("registers session_start handler", () => {
@@ -71,6 +71,31 @@ describe("extension entry point - registrations", () => {
   it("registers tool_execution_end handler", () => {
     const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
     expect(events).toContain("tool_execution_end");
+  });
+
+  it("registers turn_start handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("turn_start");
+  });
+
+  it("registers turn_end handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("turn_end");
+  });
+
+  it("registers user_bash handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("user_bash");
+  });
+
+  it("registers session_compact handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("session_compact");
+  });
+
+  it("registers model_select handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("model_select");
   });
 
   it("registers exactly 6 slash commands", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,13 @@ import { cleanOldArchives } from "./observations.js";
 import { handleToolStart, handleToolEnd } from "./tool-observer.js";
 import { handleBeforeAgentStart, handleAgentEnd } from "./prompt-observer.js";
 import {
+  handleTurnStart,
+  handleTurnEnd,
+  handleUserBash,
+  handleSessionCompact,
+  handleModelSelect,
+} from "./session-observer.js";
+import {
   handleBeforeAgentStartInjection,
   handleAgentEndClearInstincts,
 } from "./instinct-injector.js";
@@ -95,6 +102,51 @@ export default function (pi: ExtensionAPI): void {
       handleToolEnd(event, ctx, project);
     } catch (err) {
       logError(project?.id ?? null, "tool_execution_end", err);
+    }
+  });
+
+  pi.on("turn_start", (event, ctx) => {
+    try {
+      if (!project) return;
+      handleTurnStart(event, ctx, project);
+    } catch (err) {
+      logError(project?.id ?? null, "turn_start", err);
+    }
+  });
+
+  pi.on("turn_end", (event, ctx) => {
+    try {
+      if (!project) return;
+      handleTurnEnd(event, ctx, project);
+    } catch (err) {
+      logError(project?.id ?? null, "turn_end", err);
+    }
+  });
+
+  pi.on("user_bash", (event, ctx) => {
+    try {
+      if (!project) return;
+      handleUserBash(event, ctx, project);
+    } catch (err) {
+      logError(project?.id ?? null, "user_bash", err);
+    }
+  });
+
+  pi.on("session_compact", (event, ctx) => {
+    try {
+      if (!project) return;
+      handleSessionCompact(event, ctx, project);
+    } catch (err) {
+      logError(project?.id ?? null, "session_compact", err);
+    }
+  });
+
+  pi.on("model_select", (event, ctx) => {
+    try {
+      if (!project) return;
+      handleModelSelect(event, ctx, project);
+    } catch (err) {
+      logError(project?.id ?? null, "model_select", err);
     }
   });
 

--- a/src/prompt-observer.test.ts
+++ b/src/prompt-observer.test.ts
@@ -21,6 +21,7 @@ function makeCtx(sessionId = "test-session-014") {
     sessionManager: {
       getSessionId: () => sessionId,
     },
+    getContextUsage: () => ({ tokens: 1000, contextWindow: 200000, percent: 0.5 }),
   } as unknown as import("@mariozechner/pi-coding-agent").ExtensionContext;
 }
 

--- a/src/prompt-observer.ts
+++ b/src/prompt-observer.ts
@@ -76,12 +76,16 @@ export function handleAgentEnd(
   try {
     if (shouldSkipObservation()) return;
 
+    const contextUsage = ctx.getContextUsage();
+    const tokensUsed = contextUsage?.tokens ?? undefined;
+
     const observation: Observation = {
       timestamp: new Date().toISOString(),
       event: "agent_end",
       session: getSessionId(ctx),
       project_id: project.id,
       project_name: project.name,
+      ...(tokensUsed != null ? { tokens_used: tokensUsed } : {}),
       ...buildActiveInstincts(),
     };
 

--- a/src/session-observer.test.ts
+++ b/src/session-observer.test.ts
@@ -1,0 +1,243 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { clearActiveInstincts, setCurrentActiveInstincts } from "./active-instincts.js";
+import { ensureStorageLayout } from "./storage.js";
+import {
+  handleTurnStart,
+  handleTurnEnd,
+  handleUserBash,
+  handleSessionCompact,
+  handleModelSelect,
+  type TurnStartEvent,
+  type TurnEndEvent,
+  type UserBashEvent,
+  type SessionCompactEvent,
+  type ModelSelectEvent,
+} from "./session-observer.js";
+import type { ProjectEntry } from "./types.js";
+
+function makeCtx(sessionId = "test-session-020") {
+  return {
+    sessionManager: {
+      getSessionId: () => sessionId,
+    },
+    getContextUsage: () => ({ tokens: 5000, contextWindow: 200000, percent: 2.5 }),
+  } as unknown as import("@mariozechner/pi-coding-agent").ExtensionContext;
+}
+
+function readObservations(projectId: string, baseDir: string): Record<string, unknown>[] {
+  const filePath = join(baseDir, "projects", projectId, "observations.jsonl");
+  const raw = readFileSync(filePath, "utf-8").trim();
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function lastObs(projectId: string, baseDir: string): Record<string, unknown> {
+  const obs = readObservations(projectId, baseDir);
+  const last = obs[obs.length - 1];
+  if (last === undefined) throw new Error("No observations found");
+  return last;
+}
+
+const PROJECT: ProjectEntry = {
+  id: "test-proj-020",
+  name: "test-project-020",
+  root: "/tmp/test-project-020",
+  remote: "git@github.com:test/test-project-020.git",
+  created_at: new Date().toISOString(),
+  last_seen: new Date().toISOString(),
+};
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "session-observer-test-"));
+  ensureStorageLayout(PROJECT, tmpDir);
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  clearActiveInstincts();
+});
+
+afterEach(() => {
+  clearActiveInstincts();
+});
+
+describe("handleTurnStart", () => {
+  it("records a turn_start observation with turn_index", () => {
+    const event: TurnStartEvent = { type: "turn_start", turnIndex: 3, timestamp: Date.now() };
+    handleTurnStart(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["event"]).toBe("turn_start");
+    expect(last["turn_index"]).toBe(3);
+    expect(last["session"]).toBe("test-session-020");
+    expect(last["project_id"]).toBe(PROJECT.id);
+  });
+
+  it("includes active_instincts when set", () => {
+    setCurrentActiveInstincts(["inst-a"]);
+    const event: TurnStartEvent = { type: "turn_start", turnIndex: 0, timestamp: Date.now() };
+    handleTurnStart(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["active_instincts"]).toEqual(["inst-a"]);
+  });
+});
+
+describe("handleTurnEnd", () => {
+  it("records a turn_end observation with tool_count and error_count", () => {
+    const event: TurnEndEvent = {
+      type: "turn_end",
+      turnIndex: 2,
+      message: {},
+      toolResults: [{}, {}, { isError: true }],
+    };
+    handleTurnEnd(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["event"]).toBe("turn_end");
+    expect(last["turn_index"]).toBe(2);
+    expect(last["tool_count"]).toBe(3);
+    expect(last["error_count"]).toBe(1);
+  });
+
+  it("includes tokens_used from context usage", () => {
+    const event: TurnEndEvent = {
+      type: "turn_end",
+      turnIndex: 0,
+      message: {},
+      toolResults: [],
+    };
+    handleTurnEnd(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["tokens_used"]).toBe(5000);
+  });
+
+  it("handles empty toolResults", () => {
+    const event: TurnEndEvent = {
+      type: "turn_end",
+      turnIndex: 1,
+      message: {},
+      toolResults: [],
+    };
+    handleTurnEnd(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["tool_count"]).toBe(0);
+    expect(last["error_count"]).toBe(0);
+  });
+});
+
+describe("handleUserBash", () => {
+  it("records a user_bash observation with scrubbed command", () => {
+    const event: UserBashEvent = {
+      type: "user_bash",
+      command: "npm test",
+      excludeFromContext: false,
+      cwd: "/home/user/project",
+    };
+    handleUserBash(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["event"]).toBe("user_bash");
+    expect(last["command"]).toBe("npm test");
+    expect(last["cwd"]).toBe("/home/user/project");
+  });
+
+  it("scrubs secrets from commands", () => {
+    const event: UserBashEvent = {
+      type: "user_bash",
+      command: "curl -H 'Authorization: Bearer sk-secret123' https://api.example.com",
+      excludeFromContext: false,
+      cwd: "/tmp",
+    };
+    handleUserBash(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["command"]).not.toContain("sk-secret123");
+    expect(last["command"]).toContain("[REDACTED]");
+  });
+});
+
+describe("handleSessionCompact", () => {
+  it("records a session_compact observation", () => {
+    const event: SessionCompactEvent = {
+      type: "session_compact",
+      compactionEntry: {},
+      fromExtension: false,
+    };
+    handleSessionCompact(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["event"]).toBe("session_compact");
+    expect(last["from_extension"]).toBe(false);
+  });
+
+  it("records from_extension flag when compaction is extension-triggered", () => {
+    const event: SessionCompactEvent = {
+      type: "session_compact",
+      compactionEntry: {},
+      fromExtension: true,
+    };
+    handleSessionCompact(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["from_extension"]).toBe(true);
+  });
+});
+
+describe("handleModelSelect", () => {
+  it("records a model_select observation with model info", () => {
+    const event: ModelSelectEvent = {
+      type: "model_select",
+      model: { id: "claude-sonnet-4-6" },
+      previousModel: { id: "claude-haiku-4-5" },
+      source: "set",
+    };
+    handleModelSelect(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["event"]).toBe("model_select");
+    expect(last["model"]).toBe("claude-sonnet-4-6");
+    expect(last["previous_model"]).toBe("claude-haiku-4-5");
+    expect(last["model_change_source"]).toBe("set");
+  });
+
+  it("handles undefined previousModel", () => {
+    const event: ModelSelectEvent = {
+      type: "model_select",
+      model: { id: "claude-opus-4-6" },
+      previousModel: undefined,
+      source: "restore",
+    };
+    handleModelSelect(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["model"]).toBe("claude-opus-4-6");
+    expect(last["previous_model"]).toBeUndefined();
+    expect(last["model_change_source"]).toBe("restore");
+  });
+
+  it("falls back to name when id is missing", () => {
+    const event: ModelSelectEvent = {
+      type: "model_select",
+      model: { name: "Custom Model" },
+      previousModel: undefined,
+      source: "cycle",
+    };
+    handleModelSelect(event, makeCtx(), PROJECT, tmpDir);
+
+    const last = lastObs(PROJECT.id, tmpDir);
+    expect(last["model"]).toBe("Custom Model");
+  });
+});

--- a/src/session-observer.ts
+++ b/src/session-observer.ts
@@ -1,0 +1,185 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+import { getCurrentActiveInstincts } from "./active-instincts.js";
+import { appendObservation } from "./observations.js";
+import { scrubSecrets } from "./scrubber.js";
+import { logError } from "./error-logger.js";
+import type { Observation, ProjectEntry } from "./types.js";
+
+export interface TurnStartEvent {
+  type: "turn_start";
+  turnIndex: number;
+  timestamp: number;
+}
+
+export interface TurnEndEvent {
+  type: "turn_end";
+  turnIndex: number;
+  message: unknown;
+  toolResults: unknown[];
+}
+
+export interface UserBashEvent {
+  type: "user_bash";
+  command: string;
+  excludeFromContext: boolean;
+  cwd: string;
+}
+
+export interface SessionCompactEvent {
+  type: "session_compact";
+  compactionEntry: unknown;
+  fromExtension: boolean;
+}
+
+export interface ModelSelectEvent {
+  type: "model_select";
+  model: { id?: string; name?: string };
+  previousModel: { id?: string; name?: string } | undefined;
+  source: "set" | "cycle" | "restore";
+}
+
+function getSessionId(ctx: ExtensionContext): string {
+  return ctx.sessionManager.getSessionId();
+}
+
+function buildActiveInstincts(): Pick<Observation, "active_instincts"> {
+  const ids = getCurrentActiveInstincts();
+  return ids.length > 0 ? { active_instincts: ids } : {};
+}
+
+export function handleTurnStart(
+  event: TurnStartEvent,
+  ctx: ExtensionContext,
+  project: ProjectEntry,
+  baseDir?: string
+): void {
+  try {
+    const observation: Observation = {
+      timestamp: new Date().toISOString(),
+      event: "turn_start",
+      session: getSessionId(ctx),
+      project_id: project.id,
+      project_name: project.name,
+      turn_index: event.turnIndex,
+      ...buildActiveInstincts(),
+    };
+
+    appendObservation(observation, project.id, baseDir);
+  } catch (err) {
+    logError(project.id, "session-observer:handleTurnStart", err, baseDir);
+  }
+}
+
+export function handleTurnEnd(
+  event: TurnEndEvent,
+  ctx: ExtensionContext,
+  project: ProjectEntry,
+  baseDir?: string
+): void {
+  try {
+    const toolCount = event.toolResults?.length ?? 0;
+    const errorCount = Array.isArray(event.toolResults)
+      ? event.toolResults.filter((r: unknown) => {
+          if (r && typeof r === "object" && "isError" in r) {
+            return (r as { isError: boolean }).isError;
+          }
+          return false;
+        }).length
+      : 0;
+
+    const contextUsage = ctx.getContextUsage();
+    const tokensUsed = contextUsage?.tokens ?? undefined;
+
+    const observation: Observation = {
+      timestamp: new Date().toISOString(),
+      event: "turn_end",
+      session: getSessionId(ctx),
+      project_id: project.id,
+      project_name: project.name,
+      turn_index: event.turnIndex,
+      tool_count: toolCount,
+      error_count: errorCount,
+      ...(tokensUsed != null ? { tokens_used: tokensUsed } : {}),
+      ...buildActiveInstincts(),
+    };
+
+    appendObservation(observation, project.id, baseDir);
+  } catch (err) {
+    logError(project.id, "session-observer:handleTurnEnd", err, baseDir);
+  }
+}
+
+export function handleUserBash(
+  event: UserBashEvent,
+  ctx: ExtensionContext,
+  project: ProjectEntry,
+  baseDir?: string
+): void {
+  try {
+    const observation: Observation = {
+      timestamp: new Date().toISOString(),
+      event: "user_bash",
+      session: getSessionId(ctx),
+      project_id: project.id,
+      project_name: project.name,
+      command: scrubSecrets(event.command),
+      cwd: event.cwd,
+      ...buildActiveInstincts(),
+    };
+
+    appendObservation(observation, project.id, baseDir);
+  } catch (err) {
+    logError(project.id, "session-observer:handleUserBash", err, baseDir);
+  }
+}
+
+export function handleSessionCompact(
+  event: SessionCompactEvent,
+  ctx: ExtensionContext,
+  project: ProjectEntry,
+  baseDir?: string
+): void {
+  try {
+    const observation: Observation = {
+      timestamp: new Date().toISOString(),
+      event: "session_compact",
+      session: getSessionId(ctx),
+      project_id: project.id,
+      project_name: project.name,
+      from_extension: event.fromExtension,
+      ...buildActiveInstincts(),
+    };
+
+    appendObservation(observation, project.id, baseDir);
+  } catch (err) {
+    logError(project.id, "session-observer:handleSessionCompact", err, baseDir);
+  }
+}
+
+export function handleModelSelect(
+  event: ModelSelectEvent,
+  ctx: ExtensionContext,
+  project: ProjectEntry,
+  baseDir?: string
+): void {
+  try {
+    const modelName = event.model?.id ?? event.model?.name ?? "unknown";
+    const previousModelName = event.previousModel?.id ?? event.previousModel?.name;
+
+    const observation: Observation = {
+      timestamp: new Date().toISOString(),
+      event: "model_select",
+      session: getSessionId(ctx),
+      project_id: project.id,
+      project_name: project.name,
+      model: modelName,
+      ...(previousModelName ? { previous_model: previousModelName } : {}),
+      model_change_source: event.source,
+    };
+
+    appendObservation(observation, project.id, baseDir);
+  } catch (err) {
+    logError(project.id, "session-observer:handleModelSelect", err, baseDir);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,12 @@ export type ObservationEvent =
   | "tool_start"
   | "tool_complete"
   | "user_prompt"
-  | "agent_end";
+  | "agent_end"
+  | "turn_start"
+  | "turn_end"
+  | "user_bash"
+  | "session_compact"
+  | "model_select";
 
 export interface Observation {
   timestamp: string; // ISO 8601 UTC
@@ -24,6 +29,16 @@ export interface Observation {
   output?: string;
   is_error?: boolean;
   active_instincts?: string[];
+  turn_index?: number;
+  tool_count?: number;
+  error_count?: number;
+  tokens_used?: number;
+  command?: string;
+  cwd?: string;
+  from_extension?: boolean;
+  model?: string;
+  previous_model?: string;
+  model_change_source?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds 5 new Pi SDK hook handlers (`turn_start`, `turn_end`, `user_bash`, `session_compact`, `model_select`) expanding observation coverage from 5 to 10 active hooks
- Turn boundaries enable the analyzer to detect tool call sequences within LLM response cycles (e.g. grep→read→edit patterns)
- User shell commands (`!`/`!!`) capture manual workflow steps invisible to the current system
- Session compaction events signal context window pressure for efficiency analysis
- Model selection events track user model-switching preferences
- Adds `tokens_used` to `agent_end` and `turn_end` observations via `ctx.getContextUsage()`
- Updates analyzer system prompt with new pattern detection heuristics for all new event types

## Test plan

- [x] All 409 tests pass (27 test files)
- [x] 12 new tests in `session-observer.test.ts` covering all 5 new handlers
- [x] Updated `index.test.ts` to verify 12 hook registrations (was 7)
- [x] Updated `prompt-observer.test.ts` mock to include `getContextUsage()`
- [x] Build passes with no errors
- [ ] Manual: install extension locally, run a session, verify new event types appear in `observations.jsonl`