### PR TITLE
fix: reject instincts with undefined/empty/short action or trigger fields

### DIFF
--- a/src/cli/analyze-single-shot.test.ts
+++ b/src/cli/analyze-single-shot.test.ts
@@ -10,8 +10,8 @@ import type { Instinct } from "../types.js";
 const existingInstinct: Instinct = {
   id: "read-before-edit",
   title: "Read files before editing",
-  trigger: "Before making edits",
-  action: "Read the file first",
+  trigger: "Before making edits to an existing file",
+  action: "Read the file first to understand context and patterns",
   confidence: 0.8,
   domain: "workflow",
   scope: "global",
@@ -108,8 +108,8 @@ describe("buildInstinctFromChange", () => {
       instinct: {
         id: "global-one",
         title: "Global",
-        trigger: "Always",
-        action: "Do globally",
+        trigger: "When working on any project globally",
+        action: "Do this action globally across all projects",
         confidence: 0.5,
         domain: "workflow",
         scope: "global",
@@ -129,8 +129,8 @@ describe("buildInstinctFromChange", () => {
       instinct: {
         id: "clamped",
         title: "T",
-        trigger: "X",
-        action: "Y",
+        trigger: "When confidence needs clamping in tests",
+        action: "Clamp the confidence value to valid range",
         confidence: 1.5,
         domain: "workflow",
         scope: "project",
@@ -152,8 +152,8 @@ describe("buildInstinctFromChange", () => {
       instinct: {
         id: "read-before-edit",
         title: "Read files before editing",
-        trigger: "Before editing",
-        action: "Read first",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
         confidence: 0.85,
         domain: "workflow",
         scope: "global",
@@ -177,6 +177,66 @@ describe("buildInstinctFromChange", () => {
 
   it("returns null for create with missing instinct field", () => {
     const change: InstinctChange = { action: "create" };
+    expect(buildInstinctFromChange(change, null, "proj-1")).toBeNull();
+  });
+
+  it("returns null when action is the literal string 'undefined'", () => {
+    const change: InstinctChange = {
+      action: "create",
+      instinct: {
+        id: "bad-action",
+        title: "Bad",
+        trigger: "When something happens in the project",
+        action: "undefined",
+        confidence: 0.5,
+        domain: "workflow",
+        scope: "project",
+        observation_count: 1,
+        confirmed_count: 0,
+        contradicted_count: 0,
+        inactive_count: 0,
+      },
+    };
+    expect(buildInstinctFromChange(change, null, "proj-1")).toBeNull();
+  });
+
+  it("returns null when trigger is too short", () => {
+    const change: InstinctChange = {
+      action: "create",
+      instinct: {
+        id: "bad-trigger",
+        title: "Bad",
+        trigger: "When X",
+        action: "Do something meaningful with the codebase",
+        confidence: 0.5,
+        domain: "workflow",
+        scope: "project",
+        observation_count: 1,
+        confirmed_count: 0,
+        contradicted_count: 0,
+        inactive_count: 0,
+      },
+    };
+    expect(buildInstinctFromChange(change, null, "proj-1")).toBeNull();
+  });
+
+  it("returns null when action is empty string", () => {
+    const change: InstinctChange = {
+      action: "create",
+      instinct: {
+        id: "empty-action",
+        title: "Empty",
+        trigger: "When something happens in the project",
+        action: "",
+        confidence: 0.5,
+        domain: "workflow",
+        scope: "project",
+        observation_count: 1,
+        confirmed_count: 0,
+        contradicted_count: 0,
+        inactive_count: 0,
+      },
+    };
     expect(buildInstinctFromChange(change, null, "proj-1")).toBeNull();
   });
 });

--- a/src/cli/analyze-single-shot.ts
+++ b/src/cli/analyze-single-shot.ts
@@ -9,6 +9,7 @@ import type { AssistantMessage, Context } from "@mariozechner/pi-ai";
 import { complete } from "@mariozechner/pi-ai";
 import type { Instinct } from "../types.js";
 import { serializeInstinct } from "../instinct-parser.js";
+import { validateInstinct } from "../instinct-validator.js";
 
 export interface InstinctChangePayload {
   id: string;
@@ -84,8 +85,17 @@ export function buildInstinctFromChange(
     return null;
   }
 
-  const now = new Date().toISOString();
   const payload = change.instinct;
+
+  const validation = validateInstinct({
+    action: payload.action,
+    trigger: payload.trigger,
+  });
+  if (!validation.valid) {
+    return null;
+  }
+
+  const now = new Date().toISOString();
 
   return {
     id: payload.id,

--- a/src/instinct-tools.ts
+++ b/src/instinct-tools.ts
@@ -14,6 +14,7 @@ import {
   getProjectInstinctsDir,
   getGlobalInstinctsDir,
 } from "./storage.js";
+import { validateInstinct } from "./instinct-validator.js";
 
 function getInstinctsDir(
   scope: "project" | "global",
@@ -122,6 +123,14 @@ export function createInstinctWriteTool(
       _onUpdate: unknown,
       _ctx: unknown
     ) {
+      const validation = validateInstinct({
+        action: params.action,
+        trigger: params.trigger,
+      });
+      if (!validation.valid) {
+        throw new Error(`Invalid instinct: ${validation.reason}`);
+      }
+
       const dir = getInstinctsDir(params.scope, projectId, baseDir);
       if (!dir) {
         throw new Error("Cannot write project-scoped instinct: no project detected");

--- a/src/instinct-validator.test.ts
+++ b/src/instinct-validator.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { validateInstinct } from "./instinct-validator.js";
+
+describe("validateInstinct", () => {
+  const validFields = {
+    action: "Read the file before making any edits to understand context",
+    trigger: "Before making edits to an existing file",
+  };
+
+  it("accepts valid action and trigger", () => {
+    expect(validateInstinct(validFields)).toEqual({ valid: true });
+  });
+
+  describe("rejects invalid action", () => {
+    it("rejects undefined action", () => {
+      const result = validateInstinct({ ...validFields, action: undefined });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("action");
+      expect(result.reason).toContain("undefined");
+    });
+
+    it("rejects null action", () => {
+      const result = validateInstinct({ ...validFields, action: null });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("action");
+    });
+
+    it("rejects empty string action", () => {
+      const result = validateInstinct({ ...validFields, action: "" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("action");
+    });
+
+    it("rejects literal 'undefined' string", () => {
+      const result = validateInstinct({ ...validFields, action: "undefined" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("action");
+      expect(result.reason).toContain("undefined");
+    });
+
+    it("rejects literal 'null' string", () => {
+      const result = validateInstinct({ ...validFields, action: "null" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("action");
+    });
+
+    it("rejects literal 'none' string (case-insensitive)", () => {
+      const result = validateInstinct({ ...validFields, action: "None" });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects action shorter than 10 characters", () => {
+      const result = validateInstinct({ ...validFields, action: "Do stuff" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("too short");
+    });
+
+    it("rejects whitespace-only action", () => {
+      const result = validateInstinct({ ...validFields, action: "   " });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects non-string action", () => {
+      const result = validateInstinct({ ...validFields, action: 42 });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("not a string");
+    });
+  });
+
+  describe("rejects invalid trigger", () => {
+    it("rejects undefined trigger", () => {
+      const result = validateInstinct({ ...validFields, trigger: undefined });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("trigger");
+    });
+
+    it("rejects literal 'undefined' trigger", () => {
+      const result = validateInstinct({ ...validFields, trigger: "undefined" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("trigger");
+    });
+
+    it("rejects trigger shorter than 10 characters", () => {
+      const result = validateInstinct({ ...validFields, trigger: "When X" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("too short");
+    });
+  });
+
+  it("checks action before trigger (action error takes priority)", () => {
+    const result = validateInstinct({ action: "undefined", trigger: "undefined" });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("action");
+  });
+});

--- a/src/instinct-validator.ts
+++ b/src/instinct-validator.ts
@@ -1,0 +1,50 @@
+/**
+ * Instinct validation.
+ * Rejects instincts with empty, undefined, or nonsense action/trigger fields.
+ */
+
+const MIN_FIELD_LENGTH = 10;
+const INVALID_LITERALS = new Set(["undefined", "null", "none", ""]);
+
+export interface ValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+function isInvalidField(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return `${fieldName} is ${String(value)}`;
+  }
+  if (typeof value !== "string") {
+    return `${fieldName} is not a string (got ${typeof value})`;
+  }
+  const trimmed = value.trim();
+  if (INVALID_LITERALS.has(trimmed.toLowerCase())) {
+    return `${fieldName} is the literal string "${trimmed}"`;
+  }
+  if (trimmed.length < MIN_FIELD_LENGTH) {
+    return `${fieldName} is too short (${trimmed.length} chars, minimum ${MIN_FIELD_LENGTH})`;
+  }
+  return null;
+}
+
+/**
+ * Validates that an instinct's action and trigger fields are meaningful.
+ * Returns { valid: true } or { valid: false, reason: "..." }.
+ */
+export function validateInstinct(fields: {
+  action: unknown;
+  trigger: unknown;
+}): ValidationResult {
+  const actionError = isInvalidField(fields.action, "action");
+  if (actionError) {
+    return { valid: false, reason: actionError };
+  }
+
+  const triggerError = isInvalidField(fields.trigger, "trigger");
+  if (triggerError) {
+    return { valid: false, reason: triggerError };
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Problem

Instincts were being saved to disk with the literal string `undefined` as their action body, wasting injection slots and confusing the agent.

## Root Cause

`buildInstinctFromChange()` in `analyze-single-shot.ts` did not validate the `action` field from the LLM response. Missing/empty values got stringified as `"undefined"` during serialization.

## Fix

Added `src/instinct-validator.ts` with a `validateInstinct()` function that rejects:
- Empty/undefined/null `action` or `trigger`
- `action` or `trigger` that is the literal string `"undefined"`, `"null"`, or `"none"`
- `action` or `trigger` shorter than 10 characters

Integrated into two callsites:
- **`buildInstinctFromChange()`** - returns `null` for invalid instincts (silent rejection during analysis)
- **`instinct_write` tool handler** - throws with a descriptive error message (explicit rejection for interactive use)

## Tests

- 14 new tests in `instinct-validator.test.ts` covering all rejection cases
- 3 new tests in `analyze-single-shot.test.ts` for `buildInstinctFromChange()` validation integration
- Updated existing tests with valid-length trigger/action values
- All 504 tests pass

Closes #17