### PR TITLE
feat: instinct quality validation, Jaccard dedup, and analyzer quality tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ pi-continuous-learning/
     instinct-loader.ts      # Filter + sort + cap instincts for injection
     instinct-injector.ts    # System prompt injection
     instinct-tools.ts       # LLM tool definitions (list/read/write/delete/merge)
+    instinct-validator.ts   # Field validation + Jaccard similarity dedup
     instinct-decay.ts       # Passive confidence decay
     instinct-cleanup.ts     # Auto-cleanup rules (flagged, TTL, cap enforcement)
     confidence.ts           # Pure confidence math
@@ -64,12 +65,15 @@ pi-continuous-learning/
     skill-scaffold.ts       # Skill scaffolding from instinct clusters
     command-scaffold.ts     # Command scaffolding from instinct clusters
     prompts/
-      evolve-prompt.ts      # Prompt template for /instinct-evolve
-      analyzer-user.ts      # User prompt builder for background analyzer
+      evolve-prompt.ts                  # Prompt template for /instinct-evolve
+      analyzer-user.ts                  # User prompt builder (legacy agentic analyzer)
+      analyzer-system-single-shot.ts    # System prompt for single-shot analyzer
+      analyzer-user-single-shot.ts      # User prompt builder for single-shot analyzer
     cli/
       analyze.ts            # Standalone analyzer script (run via cron)
       analyze-logger.ts     # Structured JSON logger for analyzer runs
-      analyze-prompt.ts     # System prompt for background analyzer
+      analyze-prompt.ts     # System prompt (legacy agentic analyzer)
+      analyze-single-shot.ts  # Single-shot core: parseChanges, buildInstinctFromChange
   docs/
     internals.md            # Internal architecture reference
     specification.md        # Original design specification

--- a/README.md
+++ b/README.md
@@ -256,6 +256,35 @@ graduated_at: "2026-03-27T12:00:00.000Z"
 ---
 ```
 
+## Instinct Quality Control
+
+Every instinct write (from the LLM tools or the background analyzer) is validated and deduplicated before being saved.
+
+### Content Validation
+
+| Rule | Details |
+|---|---|
+| Non-empty fields | `action` and `trigger` cannot be `undefined`, `null`, `"null"`, `"none"`, or empty |
+| Minimum length | Both fields must be >= 10 characters |
+| Known domain | `domain` must be in the known set: `git`, `testing`, `debugging`, `workflow`, `typescript`, `javascript`, `python`, `go`, `css`, `design`, `security`, `performance`, `documentation`, `react`, `node`, `database`, `api`, `devops`, `architecture`, or `other` |
+| Verb heuristic | `action` should start with an imperative verb - a warning is logged but the write is not rejected |
+
+### Semantic Deduplication
+
+Before a new instinct is created, a Jaccard similarity check runs against all existing instincts. Tokenize `trigger + action`, compute `|intersection| / |union|`, and block the write if any existing instinct scores >= 0.6.
+
+This prevents near-duplicate instincts from accumulating. When a similar instinct exists, the LLM is told to update the existing one instead.
+
+### Analyzer Quality Tiers
+
+The background analyzer is instructed to classify patterns before recording them:
+
+- **Project Conventions** (Tier 1): Project-specific patterns like "use Result<T,E> for errors in this codebase" → record as project-scoped instinct
+- **Workflow Patterns** (Tier 2): Universal multi-step workflows → record as global-scoped instinct
+- **Generic Agent Behavior** (Tier 3): Read-before-edit, clarify-before-implement, check-errors-after-tool-calls → **skip entirely**, these are fundamental behaviors not learned patterns
+
+The analyzer also checks AGENTS.md content before creating instincts - if a pattern is already covered by AGENTS.md, it is skipped.
+
 ## Confidence Scoring
 
 Confidence comes from two sources:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -220,9 +220,48 @@ active-instincts.ts  -- store injected IDs in module-level state for observer to
 
 ### 4. Analyzer Prompts
 
-**System prompt** (`cli/analyze-prompt.ts`): Contains pattern detection heuristics, feedback analysis instructions, confidence scoring rules, scope decision guide, and conservativeness rules. Instructs the LLM to use `instinct_read`/`instinct_write` tools.
+**System prompt** (`prompts/analyzer-system-single-shot.ts`): Contains pattern detection heuristics, feedback analysis instructions, confidence scoring rules, scope decision guide, conservativeness rules, and quality tier guidance. The quality tier section instructs the model to distinguish between:
+- **Tier 1 - Project Conventions**: Record as project-scoped instincts
+- **Tier 2 - Workflow Patterns**: Record as global-scoped instincts
+- **Tier 3 - Generic Agent Behavior**: Skip - these belong in AGENTS.md, not instincts
 
-**User prompt** (`prompts/analyzer-user.ts`): Built fresh each run. Contains project context (ID and name), file paths, and the last 500 observation lines inlined.
+The prompt includes negative examples ("Do NOT create instincts for read-before-edit, clarify-before-implement") and instructs the model to skip patterns already covered by AGENTS.md.
+
+**User prompt** (`prompts/analyzer-user-single-shot.ts`): Built fresh each run. Contains project context, all existing instincts inline, filtered observations, AGENTS.md content (project + global), and explicit dedup instructions to skip AGENTS.md-covered patterns.
+
+---
+
+## Instinct Quality Validation
+
+All instinct writes go through `validateInstinct()` in `instinct-validator.ts` before being persisted.
+
+### Validation Rules (rejection)
+
+| Rule | Details |
+|---|---|
+| Non-empty fields | `action` and `trigger` must not be `undefined`, `null`, `"undefined"`, `"null"`, `"none"`, or empty |
+| Minimum length | Both fields must be at least 10 characters (after trimming) |
+| Type check | Both fields must be strings |
+| Known domain | `domain`, if provided, must be in the known set (see `KNOWN_DOMAINS` in `instinct-validator.ts`). Use `"other"` as an escape hatch for patterns that don't fit. |
+
+### Validation Rules (warnings)
+
+| Rule | Details |
+|---|---|
+| Verb heuristic | `action` should start with an imperative verb from `KNOWN_VERBS`. A warning is returned but the instinct is not rejected. |
+
+### Semantic Deduplication
+
+Before a new instinct is persisted (via `instinct_write` tool or the analyzer), a Jaccard similarity check runs against all existing instincts.
+
+**Algorithm** (`findSimilarInstinct()` in `instinct-validator.ts`):
+1. Tokenize `trigger + action` for the candidate and each existing instinct (lowercase, strip stop words, deduplicate)
+2. Compute Jaccard similarity: `|intersection| / |union|`
+3. If any existing instinct scores >= 0.6, the write is blocked - the caller is told to update the existing instinct instead
+
+This prevents near-duplicate instincts from accumulating when patterns are detected multiple times with slightly different wording (e.g., "read-before-edit" and "verify-edit-context").
+
+The `skipId` parameter allows the similarity check to ignore the instinct being updated (self-updates are always allowed).
 
 ---
 

--- a/src/cli/analyze-single-shot.ts
+++ b/src/cli/analyze-single-shot.ts
@@ -9,7 +9,7 @@ import type { AssistantMessage, Context } from "@mariozechner/pi-ai";
 import { complete } from "@mariozechner/pi-ai";
 import type { Instinct } from "../types.js";
 import { serializeInstinct } from "../instinct-parser.js";
-import { validateInstinct } from "../instinct-validator.js";
+import { validateInstinct, findSimilarInstinct } from "../instinct-validator.js";
 
 export interface InstinctChangePayload {
   id: string;
@@ -74,12 +74,19 @@ export function parseChanges(raw: string): InstinctChange[] {
 
 /**
  * Builds a full Instinct from a create/update change.
- * Returns null for delete changes or changes with missing instinct data.
+ * Returns null for delete changes, changes with missing instinct data,
+ * invalid fields, or semantically duplicate actions.
+ *
+ * @param change        - The change to apply
+ * @param existing      - The existing instinct with this ID, if any
+ * @param projectId     - Project ID for scoping
+ * @param allInstincts  - All current instincts, used for dedup check on creates
  */
 export function buildInstinctFromChange(
   change: InstinctChange,
   existing: Instinct | null,
-  projectId: string
+  projectId: string,
+  allInstincts: Instinct[] = []
 ): Instinct | null {
   if (change.action === "delete" || !change.instinct) {
     return null;
@@ -90,9 +97,22 @@ export function buildInstinctFromChange(
   const validation = validateInstinct({
     action: payload.action,
     trigger: payload.trigger,
+    domain: payload.domain,
   });
   if (!validation.valid) {
     return null;
+  }
+
+  // On create, reject if semantically similar to an existing instinct (skip self on update)
+  if (change.action === "create") {
+    const similar = findSimilarInstinct(
+      { trigger: payload.trigger, action: payload.action },
+      allInstincts,
+      payload.id
+    );
+    if (similar) {
+      return null;
+    }
   }
 
   const now = new Date().toISOString();

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -262,7 +262,7 @@ async function analyzeProject(
       } else if (change.action === "create") {
         if (createsRemaining <= 0) continue; // rate limit reached
         const existing = allInstincts.find((i) => i.id === change.instinct?.id) ?? null;
-        const instinct = buildInstinctFromChange(change, existing, project.id);
+        const instinct = buildInstinctFromChange(change, existing, project.id, allInstincts);
         if (!instinct) continue;
 
         const dir = instinct.scope === "global" ? globalInstinctsDir : projectInstinctsDir;
@@ -272,7 +272,7 @@ async function analyzeProject(
       } else {
         // update
         const existing = allInstincts.find((i) => i.id === change.instinct?.id) ?? null;
-        const instinct = buildInstinctFromChange(change, existing, project.id);
+        const instinct = buildInstinctFromChange(change, existing, project.id, allInstincts);
         if (!instinct) continue;
 
         const dir = instinct.scope === "global" ? globalInstinctsDir : projectInstinctsDir;

--- a/src/instinct-tools.ts
+++ b/src/instinct-tools.ts
@@ -14,7 +14,7 @@ import {
   getProjectInstinctsDir,
   getGlobalInstinctsDir,
 } from "./storage.js";
-import { validateInstinct } from "./instinct-validator.js";
+import { validateInstinct, findSimilarInstinct } from "./instinct-validator.js";
 
 function getInstinctsDir(
   scope: "project" | "global",
@@ -126,6 +126,7 @@ export function createInstinctWriteTool(
       const validation = validateInstinct({
         action: params.action,
         trigger: params.trigger,
+        domain: params.domain,
       });
       if (!validation.valid) {
         throw new Error(`Invalid instinct: ${validation.reason}`);
@@ -134,6 +135,22 @@ export function createInstinctWriteTool(
       const dir = getInstinctsDir(params.scope, projectId, baseDir);
       if (!dir) {
         throw new Error("Cannot write project-scoped instinct: no project detected");
+      }
+
+      // Dedup check: reject if semantically similar to an existing instinct
+      const allInstincts = [
+        ...(projectId ? loadProjectInstincts(projectId, baseDir) : []),
+        ...loadGlobalInstincts(baseDir),
+      ];
+      const similar = findSimilarInstinct(
+        { trigger: params.trigger, action: params.action },
+        allInstincts,
+        params.id // skip self on updates
+      );
+      if (similar) {
+        throw new Error(
+          `Similar instinct already exists: "${similar.instinct.id}" (similarity: ${(similar.similarity * 100).toFixed(0)}%). Update that instinct instead of creating a duplicate.`
+        );
       }
 
       const now = new Date().toISOString();

--- a/src/instinct-validator.test.ts
+++ b/src/instinct-validator.test.ts
@@ -1,14 +1,50 @@
 import { describe, it, expect } from "vitest";
-import { validateInstinct } from "./instinct-validator.js";
+import {
+  validateInstinct,
+  tokenize,
+  jaccardSimilarity,
+  findSimilarInstinct,
+  KNOWN_DOMAINS,
+  KNOWN_VERBS,
+} from "./instinct-validator.js";
+import type { Instinct } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeInstinct(override: Partial<Instinct> = {}): Instinct {
+  return {
+    id: "test-instinct",
+    title: "Test Instinct",
+    trigger: "When writing tests for a new module",
+    action: "Use vitest and place test files alongside source as *.test.ts",
+    confidence: 0.7,
+    domain: "testing",
+    source: "personal",
+    scope: "project",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    observation_count: 5,
+    confirmed_count: 2,
+    contradicted_count: 0,
+    inactive_count: 1,
+    ...override,
+  };
+}
+
+const validFields = {
+  action: "Read the file before making any edits to understand context",
+  trigger: "Before making edits to an existing file",
+};
+
+// ---------------------------------------------------------------------------
+// validateInstinct - basic field checks
+// ---------------------------------------------------------------------------
 
 describe("validateInstinct", () => {
-  const validFields = {
-    action: "Read the file before making any edits to understand context",
-    trigger: "Before making edits to an existing file",
-  };
-
   it("accepts valid action and trigger", () => {
-    expect(validateInstinct(validFields)).toEqual({ valid: true });
+    expect(validateInstinct(validFields)).toMatchObject({ valid: true });
   });
 
   describe("rejects invalid action", () => {
@@ -91,5 +127,277 @@ describe("validateInstinct", () => {
     const result = validateInstinct({ action: "undefined", trigger: "undefined" });
     expect(result.valid).toBe(false);
     expect(result.reason).toContain("action");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Domain validation
+  // ---------------------------------------------------------------------------
+
+  describe("domain validation", () => {
+    it("accepts known domain", () => {
+      const result = validateInstinct({ ...validFields, domain: "typescript" });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts 'other' as escape hatch", () => {
+      const result = validateInstinct({ ...validFields, domain: "other" });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts all domains in KNOWN_DOMAINS", () => {
+      for (const domain of KNOWN_DOMAINS) {
+        const result = validateInstinct({ ...validFields, domain });
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it("rejects unknown domain", () => {
+      const result = validateInstinct({ ...validFields, domain: "unicorns" });
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("unicorns");
+      expect(result.reason).toContain("known set");
+    });
+
+    it("is case-insensitive for domain matching", () => {
+      const result = validateInstinct({ ...validFields, domain: "TypeScript" });
+      expect(result.valid).toBe(true);
+    });
+
+    it("skips domain check when domain is not provided", () => {
+      const result = validateInstinct({ ...validFields });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Verb heuristic (warning, not rejection)
+  // ---------------------------------------------------------------------------
+
+  describe("verb heuristic", () => {
+    it("issues no warning when action starts with a known verb", () => {
+      const result = validateInstinct({
+        ...validFields,
+        action: "Use vitest for all new test files in this project",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("includes a warning when action does not start with a known verb", () => {
+      const result = validateInstinct({
+        ...validFields,
+        action: "File-based testing is the convention in this project",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings![0]).toContain("imperative verb");
+    });
+
+    it("does not reject the instinct for a missing verb", () => {
+      const result = validateInstinct({
+        ...validFields,
+        action: "Tests should always be placed alongside source files here",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("includes the unrecognised first word in the warning", () => {
+      const result = validateInstinct({
+        ...validFields,
+        action: "Sometimes the agent should double-check its own output",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings![0]).toContain("sometimes");
+    });
+
+    it("all KNOWN_VERBS produce no warning", () => {
+      for (const verb of KNOWN_VERBS) {
+        const action = `${verb.charAt(0).toUpperCase() + verb.slice(1)} the thing when starting work on the task`;
+        const result = validateInstinct({ ...validFields, action });
+        expect(result.warnings).toBeUndefined();
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tokenize
+// ---------------------------------------------------------------------------
+
+describe("tokenize", () => {
+  it("returns lowercase tokens", () => {
+    const tokens = tokenize("Read THE File");
+    expect(tokens.has("read")).toBe(true);
+    expect(tokens.has("file")).toBe(true);
+  });
+
+  it("filters stop words", () => {
+    const tokens = tokenize("read the file and edit it");
+    expect(tokens.has("the")).toBe(false);
+    expect(tokens.has("it")).toBe(false);
+    expect(tokens.has("and")).toBe(false);
+    expect(tokens.has("read")).toBe(true);
+    expect(tokens.has("file")).toBe(true);
+    expect(tokens.has("edit")).toBe(true);
+  });
+
+  it("filters short tokens (length <= 2)", () => {
+    const tokens = tokenize("do it in a new way");
+    expect(tokens.has("do")).toBe(false);
+    expect(tokens.has("in")).toBe(false);
+    expect(tokens.has("a")).toBe(false);
+  });
+
+  it("splits on non-alphanumeric characters", () => {
+    const tokens = tokenize("read-before-edit: always check first");
+    expect(tokens.has("read")).toBe(true);
+    expect(tokens.has("before")).toBe(true); // not a stop word - meaningful token
+    expect(tokens.has("edit")).toBe(true);
+    expect(tokens.has("always")).toBe(true);
+    expect(tokens.has("check")).toBe(true);
+    expect(tokens.has("first")).toBe(true);
+  });
+
+  it("returns a set (deduplicates)", () => {
+    const tokens = tokenize("read read read the file file");
+    expect(tokens.size).toBe(2); // "read", "file"
+  });
+
+  it("returns empty set for stop-word-only text", () => {
+    const tokens = tokenize("a the is of");
+    expect(tokens.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jaccardSimilarity
+// ---------------------------------------------------------------------------
+
+describe("jaccardSimilarity", () => {
+  it("returns 1.0 for identical sets", () => {
+    const s = new Set(["read", "file", "edit"]);
+    expect(jaccardSimilarity(s, s)).toBe(1.0);
+  });
+
+  it("returns 0.0 for completely disjoint sets", () => {
+    const a = new Set(["read", "file"]);
+    const b = new Set(["write", "document"]);
+    expect(jaccardSimilarity(a, b)).toBe(0.0);
+  });
+
+  it("returns 1.0 for two empty sets", () => {
+    expect(jaccardSimilarity(new Set(), new Set())).toBe(1.0);
+  });
+
+  it("returns 0.0 when one set is empty", () => {
+    expect(jaccardSimilarity(new Set(["read"]), new Set())).toBe(0.0);
+    expect(jaccardSimilarity(new Set(), new Set(["read"]))).toBe(0.0);
+  });
+
+  it("returns partial overlap correctly", () => {
+    const a = new Set(["read", "file", "edit"]);
+    const b = new Set(["read", "file", "write"]);
+    // intersection: {read, file} = 2
+    // union: {read, file, edit, write} = 4
+    expect(jaccardSimilarity(a, b)).toBeCloseTo(2 / 4, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSimilarInstinct
+// ---------------------------------------------------------------------------
+
+describe("findSimilarInstinct", () => {
+  const readBeforeEdit = makeInstinct({
+    id: "read-before-edit",
+    trigger: "Before making edits to an existing file",
+    action: "Read the file content first to understand current state and context before making edits",
+  });
+
+  const verifyEditContext = makeInstinct({
+    id: "verify-edit-context",
+    trigger: "When using the edit tool to modify a file after reading it",
+    action: "Ensure the oldText in the edit tool matches the exact file content and context",
+  });
+
+  const useTdd = makeInstinct({
+    id: "use-tdd",
+    trigger: "When implementing a new feature or fixing a bug",
+    action: "Write the test first before writing implementation code",
+  });
+
+  it("returns null when no existing instincts", () => {
+    const result = findSimilarInstinct(
+      { trigger: "When editing a file", action: "Read file content before editing" },
+      []
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no instinct exceeds threshold", () => {
+    const result = findSimilarInstinct(
+      { trigger: "When writing Python code", action: "Use type hints for all function parameters" },
+      [readBeforeEdit, verifyEditContext, useTdd]
+    );
+    expect(result).toBeNull();
+  });
+
+  it("detects highly similar instincts above default threshold", () => {
+    // This is very similar to readBeforeEdit
+    const candidate = {
+      trigger: "Before making edits to a file that exists",
+      action: "Read the file content to understand the current state before editing",
+    };
+    const result = findSimilarInstinct(candidate, [readBeforeEdit, useTdd]);
+    expect(result).not.toBeNull();
+    expect(result!.instinct.id).toBe("read-before-edit");
+    expect(result!.similarity).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it("respects skipId to avoid matching the instinct being updated", () => {
+    const candidate = {
+      trigger: "Before making edits to a file that exists",
+      action: "Read the file content to understand the current state before editing",
+    };
+    // Skip the similar instinct - simulates updating read-before-edit itself
+    const result = findSimilarInstinct(candidate, [readBeforeEdit, useTdd], "read-before-edit");
+    expect(result).toBeNull();
+  });
+
+  it("returns the best (highest similarity) match when multiple qualify", () => {
+    const veryClose = makeInstinct({
+      id: "read-file-first",
+      trigger: "Before making edits to any existing file",
+      action: "Read the file content first to understand the current state and context",
+    });
+    const lessSimilar = makeInstinct({
+      id: "check-file-exists",
+      trigger: "Before editing a file in the project",
+      action: "Read the file to confirm it exists and understand the structure",
+    });
+
+    const candidate = {
+      trigger: "Before making edits to an existing file in the codebase",
+      action: "Read the file content to understand the current state before making edits",
+    };
+
+    const result = findSimilarInstinct(candidate, [veryClose, lessSimilar]);
+    expect(result).not.toBeNull();
+    // Should return the one with higher similarity
+    expect(result!.instinct.id).toBe("read-file-first");
+  });
+
+  it("respects custom threshold", () => {
+    const candidate = {
+      trigger: "Before making edits to a file",
+      action: "Read the file content before editing",
+    };
+    // With very high threshold (0.95), should not match
+    const highThreshold = findSimilarInstinct(candidate, [readBeforeEdit], undefined, 0.95);
+    expect(highThreshold).toBeNull();
+
+    // With low threshold (0.3), should match
+    const lowThreshold = findSimilarInstinct(candidate, [readBeforeEdit], undefined, 0.3);
+    expect(lowThreshold).not.toBeNull();
   });
 });

--- a/src/instinct-validator.ts
+++ b/src/instinct-validator.ts
@@ -1,15 +1,134 @@
 /**
- * Instinct validation.
- * Rejects instincts with empty, undefined, or nonsense action/trigger fields.
+ * Instinct validation and semantic deduplication.
+ * Rejects instincts with empty, undefined, nonsense, or low-quality fields,
+ * and detects near-duplicate instincts via Jaccard similarity.
  */
+
+import type { Instinct } from "./types.js";
 
 const MIN_FIELD_LENGTH = 10;
 const INVALID_LITERALS = new Set(["undefined", "null", "none", ""]);
 
+// ---------------------------------------------------------------------------
+// Known domains (with "other" as escape hatch)
+// ---------------------------------------------------------------------------
+
+export const KNOWN_DOMAINS = new Set([
+  "git",
+  "testing",
+  "debugging",
+  "workflow",
+  "typescript",
+  "javascript",
+  "python",
+  "go",
+  "css",
+  "design",
+  "security",
+  "performance",
+  "documentation",
+  "react",
+  "node",
+  "database",
+  "api",
+  "devops",
+  "architecture",
+  "other",
+]);
+
+// ---------------------------------------------------------------------------
+// Verb heuristic for action field
+// ---------------------------------------------------------------------------
+
+/** Common imperative verbs expected at the start of an instinct action. */
+export const KNOWN_VERBS = new Set([
+  "add",
+  "always",
+  "analyze",
+  "apply",
+  "ask",
+  "avoid",
+  "build",
+  "call",
+  "catch",
+  "check",
+  "clean",
+  "confirm",
+  "consider",
+  "create",
+  "define",
+  "delete",
+  "document",
+  "emit",
+  "ensure",
+  "exclude",
+  "export",
+  "extract",
+  "fetch",
+  "find",
+  "fix",
+  "follow",
+  "format",
+  "generate",
+  "get",
+  "handle",
+  "import",
+  "include",
+  "inspect",
+  "load",
+  "log",
+  "look",
+  "merge",
+  "monitor",
+  "move",
+  "never",
+  "parse",
+  "pass",
+  "prefer",
+  "print",
+  "read",
+  "record",
+  "refactor",
+  "reject",
+  "rename",
+  "require",
+  "resolve",
+  "return",
+  "run",
+  "save",
+  "scan",
+  "search",
+  "send",
+  "set",
+  "show",
+  "skip",
+  "start",
+  "stop",
+  "test",
+  "track",
+  "update",
+  "use",
+  "validate",
+  "verify",
+  "watch",
+  "wrap",
+  "write",
+]);
+
+// ---------------------------------------------------------------------------
+// Validation types
+// ---------------------------------------------------------------------------
+
 export interface ValidationResult {
   valid: boolean;
   reason?: string;
+  /** Non-fatal warnings that indicate lower-quality instincts. */
+  warnings?: string[];
 }
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
 
 function isInvalidField(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
@@ -28,13 +147,25 @@ function isInvalidField(value: unknown, fieldName: string): string | null {
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// validateInstinct
+// ---------------------------------------------------------------------------
+
 /**
- * Validates that an instinct's action and trigger fields are meaningful.
+ * Validates that an instinct's fields meet quality requirements.
+ *
+ * Rules:
+ * - action and trigger must be non-empty, non-null, non-"undefined", and >= 10 chars
+ * - action first word should be a known imperative verb (warning if not)
+ * - domain, if provided, must be in KNOWN_DOMAINS (with "other" as escape hatch)
+ *
  * Returns { valid: true } or { valid: false, reason: "..." }.
+ * Non-fatal issues are reported in the optional `warnings` array.
  */
 export function validateInstinct(fields: {
   action: unknown;
   trigger: unknown;
+  domain?: unknown;
 }): ValidationResult {
   const actionError = isInvalidField(fields.action, "action");
   if (actionError) {
@@ -46,5 +177,111 @@ export function validateInstinct(fields: {
     return { valid: false, reason: triggerError };
   }
 
-  return { valid: true };
+  const warnings: string[] = [];
+
+  // Domain validation
+  if (fields.domain !== undefined) {
+    if (typeof fields.domain !== "string" || !KNOWN_DOMAINS.has(fields.domain.toLowerCase().trim())) {
+      return {
+        valid: false,
+        reason: `domain "${String(fields.domain)}" is not in the known set. Use one of: ${[...KNOWN_DOMAINS].join(", ")}`,
+      };
+    }
+  }
+
+  // Verb heuristic (warning only - does not reject)
+  const action = (fields.action as string).trim();
+  const firstWord = action.split(/\s+/)[0]?.toLowerCase() ?? "";
+  if (firstWord && !KNOWN_VERBS.has(firstWord)) {
+    warnings.push(
+      `action should start with an imperative verb (got "${firstWord}"). Consider rewriting as a clear instruction.`
+    );
+  }
+
+  return warnings.length > 0 ? { valid: true, warnings } : { valid: true };
+}
+
+// ---------------------------------------------------------------------------
+// Jaccard similarity deduplication
+// ---------------------------------------------------------------------------
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "should",
+  "could", "may", "might", "shall", "can", "of", "in", "on", "at", "to",
+  "for", "with", "by", "from", "up", "about", "into", "it", "its", "this",
+  "that", "these", "those", "and", "or", "but", "if", "as", "when", "where",
+  "how", "what", "which", "who", "not", "no", "so",
+]);
+
+/**
+ * Tokenizes text into a set of meaningful lowercase words.
+ * Splits on non-alphanumeric characters and filters stop words and short tokens.
+ */
+export function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 2 && !STOP_WORDS.has(t))
+  );
+}
+
+/**
+ * Computes Jaccard similarity between two token sets.
+ * Returns 1.0 for two empty sets, 0.0 if one is empty.
+ */
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1.0;
+  if (a.size === 0 || b.size === 0) return 0.0;
+
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+
+  const union = a.size + b.size - intersection;
+  return intersection / union;
+}
+
+export interface SimilarityMatch {
+  instinct: Instinct;
+  similarity: number;
+}
+
+/**
+ * Checks whether a candidate instinct is semantically similar to any existing instinct.
+ *
+ * Tokenizes trigger+action for both candidate and each existing instinct,
+ * computes Jaccard similarity, and returns the closest match above the threshold.
+ *
+ * @param candidate  - The new instinct being considered (trigger + action)
+ * @param existing   - All current instincts to check against
+ * @param skipId     - ID to skip (the candidate's own ID on updates)
+ * @param threshold  - Similarity threshold; default 0.6
+ */
+export function findSimilarInstinct(
+  candidate: { trigger: string; action: string },
+  existing: Instinct[],
+  skipId?: string,
+  threshold = 0.6
+): SimilarityMatch | null {
+  const candidateTokens = tokenize(`${candidate.trigger} ${candidate.action}`);
+
+  let bestMatch: SimilarityMatch | null = null;
+
+  for (const instinct of existing) {
+    if (instinct.id === skipId) continue;
+
+    const existingTokens = tokenize(`${instinct.trigger} ${instinct.action}`);
+    const similarity = jaccardSimilarity(candidateTokens, existingTokens);
+
+    if (similarity >= threshold) {
+      if (bestMatch === null || similarity > bestMatch.similarity) {
+        bestMatch = { instinct, similarity };
+      }
+    }
+  }
+
+  return bestMatch;
 }

--- a/src/prompts/analyzer-system-single-shot.ts
+++ b/src/prompts/analyzer-system-single-shot.ts
@@ -119,5 +119,45 @@ When in doubt, prefer project scope.
 4. New instincts from observation data alone are capped at 0.85 confidence.
 5. Check existing instincts (provided in the user message) for duplicates before creating. Update instead.
 6. Write actions as clear instructions starting with a verb.
-7. Be skeptical of outliers - patterns seen only in unusual circumstances should not become instincts.`;
+7. Be skeptical of outliers - patterns seen only in unusual circumstances should not become instincts.
+
+## Quality Tiers
+
+Not all patterns are worth recording as instincts. Use this classification before creating:
+
+### Tier 1 - Project Conventions (RECORD as instinct)
+Patterns specific to this project's tech stack, codebase conventions, or team practices.
+Examples:
+- "Use the Result<T, E> type for error handling in this project"
+- "Place tests next to source files as *.test.ts"
+- "Prefer functional style - avoid class-based patterns in this codebase"
+
+### Tier 2 - Workflow Patterns (RECORD as global instinct)
+Recurring multi-step workflows that apply across many projects.
+Examples:
+- "Run linter and type-checker after every code change"
+- "Write tests before implementation in TDD projects"
+
+### Tier 3 - Generic Agent Behavior (DO NOT RECORD - already known)
+Fundamental behaviors all coding agents should follow. These are not project-specific patterns.
+
+**DO NOT create instincts for:**
+- Reading files before editing them ("read before edit")
+- Grepping for context before modifying code
+- Clarifying ambiguous requirements before starting
+- Using conventional commit message formats
+- Checking for errors after tool calls
+- Any behavior that is basic good practice for any coding agent
+
+These patterns belong in AGENTS.md from the start, not in learned instincts.
+
+## AGENTS.md Deduplication
+
+The user message includes the current AGENTS.md content for this project and globally.
+Before creating any instinct, check: **is this pattern already covered by AGENTS.md?**
+
+If yes: do NOT create an instinct. The pattern is already enforced.
+If a pattern appears in AGENTS.md in the same form, skip it entirely.
+
+Only create instincts for patterns that are genuinely absent from AGENTS.md.`;
 }

--- a/src/prompts/analyzer-user-single-shot.ts
+++ b/src/prompts/analyzer-user-single-shot.ts
@@ -80,6 +80,12 @@ export function buildSingleShotUserPrompt(
     "3. Return a JSON change-set: create new instincts, update existing ones, or delete obsolete ones.",
     "4. Apply feedback analysis using the active_instincts field in each observation.",
     "5. Passive confidence decay has already been applied before this analysis.",
+    "6. Before creating any instinct, check the Existing Guidelines section above.",
+    "   If the pattern is already covered by AGENTS.md, do NOT create an instinct for it.",
+    "7. Apply the Quality Tier rules from the system prompt:",
+    "   - Generic agent behaviors (read-before-edit, clarify-before-implement) -> skip entirely",
+    "   - Project-specific patterns -> project-scoped instinct",
+    "   - Universal workflow patterns -> global-scoped instinct",
     "",
     "Return ONLY the JSON object. No prose, no markdown fences."
   );


### PR DESCRIPTION
## Summary

Closes #20

Implements all acceptance criteria from the instinct quality issue:

### 1. Enhanced `validateInstinct()`

- **Domain validation**: `domain` must be from the `KNOWN_DOMAINS` set (`git`, `testing`, `workflow`, `typescript`, etc.) with `"other"` as an escape hatch. Rejects unknown domains.
- **Verb heuristic**: `action` should start with an imperative verb from `KNOWN_VERBS`. Returns a warning (not rejection) when the first word isn't recognised.
- Existing field checks (non-empty, non-null, min 10 chars) unchanged.

### 2. Jaccard similarity deduplication

New exports in `instinct-validator.ts`:
- `tokenize(text)` - lowercase, split on non-alphanumeric, filter stop words
- `jaccardSimilarity(a, b)` - `|intersection| / |union|`
- `findSimilarInstinct(candidate, existing, skipId?, threshold?)` - returns the closest match above 0.6

Both write paths are protected:
- **`instinct_write` tool**: loads all project+global instincts, runs dedup check, throws if similarity >= 0.6 with message telling the LLM to update the existing instinct
- **`buildInstinctFromChange()`**: skips the create if dedup check fires (returns `null`)

### 3. Analyzer quality tiers and AGENTS.md dedup

System prompt (`analyzer-system-single-shot.ts`) now includes:
- **Quality Tier 1 - Project Conventions**: record as project-scoped instinct
- **Quality Tier 2 - Workflow Patterns**: record as global-scoped instinct  
- **Quality Tier 3 - Generic Agent Behavior**: skip entirely (read-before-edit, clarify-before-implement, etc.)
- Negative examples explicitly listed
- Instruction to check AGENTS.md before creating any instinct

User prompt (`analyzer-user-single-shot.ts`) adds explicit instructions 6+7 to apply these rules.

### 4. Tests

42 tests in `instinct-validator.test.ts` (up from 14):
- Domain validation (known set, escape hatch, case-insensitive, rejection)
- Verb heuristic (warning present/absent, all KNOWN_VERBS produce no warning)
- `tokenize` (stop words, short tokens, dedup, non-alphanumeric splits)
- `jaccardSimilarity` (identical, disjoint, empty, partial overlap)
- `findSimilarInstinct` (no match, threshold, skipId, best-match selection, custom threshold)

### 5. Docs

- `docs/internals.md`: new **Instinct Quality Validation** section covering validation rules table, verb heuristic, and dedup algorithm
- `README.md`: new **Instinct Quality Control** section with tables and quality tier summary
- `AGENTS.md`: updated directory structure with `instinct-validator.ts` and single-shot prompt files