### PR TITLE
fix: reduce confirmation bias with session dedup, baseline filtering, and diminishing returns

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -315,11 +315,32 @@ Pure functions in `confidence.ts`. No I/O.
 
 ### Feedback adjustments (existing instincts)
 
-| Outcome | Delta |
-|---|---|
-| Confirmed | +0.05 |
-| Contradicted | -0.15 |
-| Inactive | 0 |
+Confirmations use **diminishing returns** to prevent high-volume, easy-to-confirm instincts
+from reaching maximum confidence prematurely. The delta is based on `confirmed_count` at
+the time of the confirmation:
+
+| Outcome | Condition | Delta |
+|---|---|---|
+| Confirmed | confirmed_count 0-3 (1st-3rd confirmation) | +0.05 |
+| Confirmed | confirmed_count 4-6 (4th-6th confirmation) | +0.03 |
+| Confirmed | confirmed_count 7+ (7th+ confirmation) | +0.01 |
+| Contradicted | - | -0.15 |
+| Inactive | - | 0 |
+
+**Per-session deduplication**: An instinct may only be confirmed once per unique session_id.
+The `last_confirmed_session` field on each instinct tracks the session that last provided a
+confirmation. If the current analysis window only contains activity from that same session,
+`confirmed_count` is not incremented. This prevents the same session from providing
+multiple confirmation credits to the same instinct.
+
+**Baseline behavior filtering**: The analyzer prompt instructs the model not to mark generic
+agent behaviors (e.g., "read before edit", "run linter after change") as confirmed, since those
+would happen regardless of the instinct. Only behaviors that are non-obvious or project-specific
+should be counted as confirmed.
+
+The `adjustConfidence(current, outcome, confirmedCount)` function in `confidence.ts` computes
+the delta for a single adjustment. Client-side enforcement in `buildInstinctFromChange()` applies
+the diminishing returns and session deduplication independently of the LLM's arithmetic.
 
 ### Passive decay
 
@@ -410,7 +431,7 @@ The single-shot analyzer applies several strategies to reduce prompt token usage
 
 ### 1. Compact Instinct Format
 
-`formatInstinctsCompact()` in `cli/analyze-single-shot.ts` serializes instincts as a compact JSON array instead of full YAML frontmatter + markdown body. Each entry contains only the fields the model needs: `{id, trigger, action, confidence, domain, scope, confirmed, contradicted, inactive, age_days}`.
+`formatInstinctsCompact()` in `cli/analyze-single-shot.ts` serializes instincts as a compact JSON array instead of full YAML frontmatter + markdown body. Each entry contains only the fields the model needs: `{id, trigger, action, confidence, domain, scope, confirmed, contradicted, inactive, age_days, last_confirmed_session?}`. The `last_confirmed_session` field is included only when set, so the analyzer can enforce per-session confirmation deduplication.
 
 This reduces instinct context by ~70% vs. the legacy `formatInstinctsForPrompt()` (which is still exported but marked deprecated). The user prompt builder uses compact format by default.
 

--- a/src/cli/analyze-single-shot.test.ts
+++ b/src/cli/analyze-single-shot.test.ts
@@ -163,13 +163,157 @@ describe("buildInstinctFromChange", () => {
         confirmed_count: 3,
         contradicted_count: 0,
         inactive_count: 1,
+        last_confirmed_session: "session-new",
       },
     };
     const result = buildInstinctFromChange(change, existingInstinct, "proj-1");
-    expect(result?.confidence).toBe(0.85);
+    // confidence recomputed client-side: existing 0.8 + tier-1 delta 0.05 = 0.85
+    expect(result?.confidence).toBeCloseTo(0.85);
     expect(result?.observation_count).toBe(6);
     expect(result?.created_at).toBe(existingInstinct.created_at);
     expect(result?.updated_at).not.toBe(existingInstinct.updated_at);
+    expect(result?.last_confirmed_session).toBe("session-new");
+  });
+
+  it("applies diminishing returns: tier-2 delta for 4th-6th confirmation", () => {
+    const highCountInstinct: Instinct = {
+      ...existingInstinct,
+      confirmed_count: 4,
+      confidence: 0.7,
+      last_confirmed_session: "session-old",
+    };
+    const change: InstinctChange = {
+      action: "update",
+      instinct: {
+        id: "read-before-edit",
+        title: "Read files before editing",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
+        confidence: 0.9,
+        domain: "workflow",
+        scope: "global",
+        observation_count: 8,
+        confirmed_count: 5, // +1 from 4
+        contradicted_count: 0,
+        inactive_count: 1,
+        last_confirmed_session: "session-new",
+      },
+    };
+    const result = buildInstinctFromChange(change, highCountInstinct, "proj-1");
+    // tier-2 delta: 0.7 + 0.03 = 0.73
+    expect(result?.confidence).toBeCloseTo(0.73);
+  });
+
+  it("applies diminishing returns: tier-3 delta for 7th+ confirmation", () => {
+    const highCountInstinct: Instinct = {
+      ...existingInstinct,
+      confirmed_count: 7,
+      confidence: 0.8,
+      last_confirmed_session: "session-old",
+    };
+    const change: InstinctChange = {
+      action: "update",
+      instinct: {
+        id: "read-before-edit",
+        title: "Read files before editing",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
+        confidence: 0.9,
+        domain: "workflow",
+        scope: "global",
+        observation_count: 10,
+        confirmed_count: 8, // +1 from 7
+        contradicted_count: 0,
+        inactive_count: 1,
+        last_confirmed_session: "session-new",
+      },
+    };
+    const result = buildInstinctFromChange(change, highCountInstinct, "proj-1");
+    // tier-3 delta: 0.8 + 0.01 = 0.81
+    expect(result?.confidence).toBeCloseTo(0.81);
+  });
+
+  it("blocks per-session duplicate confirmation when session matches last_confirmed_session", () => {
+    const instinctWithSession: Instinct = {
+      ...existingInstinct,
+      confirmed_count: 2,
+      confidence: 0.8,
+      last_confirmed_session: "session-abc",
+    };
+    const change: InstinctChange = {
+      action: "update",
+      instinct: {
+        id: "read-before-edit",
+        title: "Read files before editing",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
+        confidence: 0.85,
+        domain: "workflow",
+        scope: "global",
+        observation_count: 6,
+        confirmed_count: 3, // LLM tried to increment
+        contradicted_count: 0,
+        inactive_count: 1,
+        last_confirmed_session: "session-abc", // same session - should be blocked
+      },
+    };
+    const result = buildInstinctFromChange(change, instinctWithSession, "proj-1");
+    // confirmed_count reverted; confidence unchanged at 0.8
+    expect(result?.confirmed_count).toBe(2);
+    expect(result?.confidence).toBeCloseTo(0.8);
+  });
+
+  it("allows confirmation when session differs from last_confirmed_session", () => {
+    const instinctWithSession: Instinct = {
+      ...existingInstinct,
+      confirmed_count: 2,
+      confidence: 0.8,
+      last_confirmed_session: "session-abc",
+    };
+    const change: InstinctChange = {
+      action: "update",
+      instinct: {
+        id: "read-before-edit",
+        title: "Read files before editing",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
+        confidence: 0.85,
+        domain: "workflow",
+        scope: "global",
+        observation_count: 6,
+        confirmed_count: 3, // +1 from different session
+        contradicted_count: 0,
+        inactive_count: 1,
+        last_confirmed_session: "session-xyz", // different session - should be allowed
+      },
+    };
+    const result = buildInstinctFromChange(change, instinctWithSession, "proj-1");
+    expect(result?.confirmed_count).toBe(3);
+    expect(result?.confidence).toBeCloseTo(0.85); // 0.8 + 0.05 (tier-1, count was 2)
+    expect(result?.last_confirmed_session).toBe("session-xyz");
+  });
+
+  it("allows confirmation when instinct has no last_confirmed_session", () => {
+    const change: InstinctChange = {
+      action: "update",
+      instinct: {
+        id: "read-before-edit",
+        title: "Read files before editing",
+        trigger: "Before editing any existing file in the project",
+        action: "Read the complete file first to understand context",
+        confidence: 0.85,
+        domain: "workflow",
+        scope: "global",
+        observation_count: 6,
+        confirmed_count: 3,
+        contradicted_count: 0,
+        inactive_count: 1,
+        last_confirmed_session: "session-xyz",
+      },
+    };
+    const result = buildInstinctFromChange(change, existingInstinct, "proj-1");
+    expect(result?.confirmed_count).toBe(3);
+    expect(result?.last_confirmed_session).toBe("session-xyz");
   });
 
   it("returns null for delete action", () => {
@@ -301,6 +445,24 @@ describe("formatInstinctsCompact", () => {
     const result = formatInstinctsCompact([existingInstinct]);
     expect(result).not.toContain("---");
     expect(result).not.toContain("observation_count:");
+  });
+
+  it("includes last_confirmed_session when set on the instinct", () => {
+    const withSession: Instinct = {
+      ...existingInstinct,
+      last_confirmed_session: "session-abc",
+    };
+    const result = formatInstinctsCompact([withSession]);
+    const parsed = JSON.parse(result) as unknown[];
+    const entry = parsed[0] as Record<string, unknown>;
+    expect(entry["last_confirmed_session"]).toBe("session-abc");
+  });
+
+  it("omits last_confirmed_session when not set on the instinct", () => {
+    const result = formatInstinctsCompact([existingInstinct]);
+    const parsed = JSON.parse(result) as unknown[];
+    const entry = parsed[0] as Record<string, unknown>;
+    expect(entry["last_confirmed_session"]).toBeUndefined();
   });
 });
 

--- a/src/cli/analyze-single-shot.ts
+++ b/src/cli/analyze-single-shot.ts
@@ -13,6 +13,7 @@ import { serializeInstinct } from "../instinct-parser.js";
 /** Chars-per-token heuristic for prompt size estimation. */
 const CHARS_PER_TOKEN = 4;
 import { validateInstinct, findSimilarInstinct } from "../instinct-validator.js";
+import { confirmationDelta } from "../confidence.js";
 
 export interface InstinctChangePayload {
   id: string;
@@ -27,6 +28,7 @@ export interface InstinctChangePayload {
   contradicted_count?: number;
   inactive_count?: number;
   evidence?: string[];
+  last_confirmed_session?: string;
 }
 
 export interface InstinctChange {
@@ -120,12 +122,57 @@ export function buildInstinctFromChange(
 
   const now = new Date().toISOString();
 
+  // For updates, recompute confidence client-side to enforce:
+  // 1. Per-session deduplication: only one confirmation per unique session_id
+  // 2. Diminishing returns: each additional confirmation yields a smaller delta
+  let resolvedConfidence: number;
+  let resolvedConfirmedCount = payload.confirmed_count ?? existing?.confirmed_count ?? 0;
+  let resolvedLastConfirmedSession = payload.last_confirmed_session ?? existing?.last_confirmed_session;
+
+  if (change.action === "update" && existing !== null) {
+    const prevConfirmedCount = existing.confirmed_count;
+    const newConfirmedCount = payload.confirmed_count ?? prevConfirmedCount;
+    const contradictionsAdded = Math.max(
+      0,
+      (payload.contradicted_count ?? 0) - existing.contradicted_count,
+    );
+
+    // Detect whether the LLM intends to add a confirmation
+    const wantsToConfirm = newConfirmedCount > prevConfirmedCount;
+
+    // Session dedup: reject the confirmation if the confirming session is the
+    // same as the one that last confirmed this instinct.
+    const sessionDuplicate =
+      wantsToConfirm &&
+      resolvedLastConfirmedSession !== undefined &&
+      payload.last_confirmed_session !== undefined &&
+      payload.last_confirmed_session === existing.last_confirmed_session;
+
+    if (sessionDuplicate) {
+      // Revert to existing count - this session already confirmed the instinct
+      resolvedConfirmedCount = prevConfirmedCount;
+    }
+
+    // Recompute confidence from existing + explicit deltas (don't trust LLM arithmetic)
+    resolvedConfidence = existing.confidence;
+    if (wantsToConfirm && !sessionDuplicate) {
+      resolvedConfidence += confirmationDelta(prevConfirmedCount);
+    }
+    if (contradictionsAdded > 0) {
+      resolvedConfidence -= 0.15 * contradictionsAdded;
+    }
+    resolvedConfidence = Math.max(0.1, Math.min(0.9, resolvedConfidence));
+  } else {
+    // For creates, trust the LLM's initial confidence (no prior state to base delta on)
+    resolvedConfidence = Math.max(0.1, Math.min(0.9, payload.confidence));
+  }
+
   return {
     id: payload.id,
     title: payload.title,
     trigger: payload.trigger,
     action: payload.action,
-    confidence: Math.max(0.1, Math.min(0.9, payload.confidence)),
+    confidence: resolvedConfidence,
     domain: payload.domain,
     scope: payload.scope,
     source: "personal",
@@ -133,10 +180,13 @@ export function buildInstinctFromChange(
     created_at: existing?.created_at ?? now,
     updated_at: now,
     observation_count: payload.observation_count ?? 1,
-    confirmed_count: payload.confirmed_count ?? 0,
+    confirmed_count: resolvedConfirmedCount,
     contradicted_count: payload.contradicted_count ?? 0,
     inactive_count: payload.inactive_count ?? 0,
     ...(payload.evidence !== undefined ? { evidence: payload.evidence } : {}),
+    ...(resolvedLastConfirmedSession !== undefined
+      ? { last_confirmed_session: resolvedLastConfirmedSession }
+      : {}),
   };
 }
 
@@ -168,6 +218,9 @@ export function formatInstinctsCompact(instincts: Instinct[]): string {
     contradicted: i.contradicted_count,
     inactive: i.inactive_count,
     age_days: daysSince(i.created_at),
+    ...(i.last_confirmed_session !== undefined
+      ? { last_confirmed_session: i.last_confirmed_session }
+      : {}),
   }));
   return JSON.stringify(summaries);
 }

--- a/src/confidence.test.ts
+++ b/src/confidence.test.ts
@@ -3,6 +3,7 @@ import {
   initialConfidence,
   adjustConfidence,
   applyPassiveDecay,
+  confirmationDelta,
 } from "./confidence.js";
 
 // ---------------------------------------------------------------------------
@@ -47,11 +48,66 @@ describe("initialConfidence", () => {
 // adjustConfidence
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// confirmationDelta
+// ---------------------------------------------------------------------------
+
+describe("confirmationDelta", () => {
+  it("returns 0.05 for 0th confirmation (count=0)", () => {
+    expect(confirmationDelta(0)).toBe(0.05);
+  });
+
+  it("returns 0.05 for 2nd confirmation (count=2)", () => {
+    expect(confirmationDelta(2)).toBe(0.05);
+  });
+
+  it("returns 0.05 for 3rd confirmation (count=3)", () => {
+    expect(confirmationDelta(3)).toBe(0.05);
+  });
+
+  it("returns 0.03 for 4th confirmation (count=4)", () => {
+    expect(confirmationDelta(4)).toBe(0.03);
+  });
+
+  it("returns 0.03 for 6th confirmation (count=6)", () => {
+    expect(confirmationDelta(6)).toBe(0.03);
+  });
+
+  it("returns 0.01 for 7th+ confirmation (count=7)", () => {
+    expect(confirmationDelta(7)).toBe(0.01);
+  });
+
+  it("returns 0.01 for very high count (count=100)", () => {
+    expect(confirmationDelta(100)).toBe(0.01);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adjustConfidence
+// ---------------------------------------------------------------------------
+
 describe("adjustConfidence", () => {
-  it("adds 0.05 for confirmed outcome", () => {
-    const result = adjustConfidence(0.5, "confirmed");
+  it("adds tier-1 delta (0.05) for first confirmation (confirmedCount=0)", () => {
+    const result = adjustConfidence(0.5, "confirmed", 0);
     expect(result.confidence).toBeCloseTo(0.55);
     expect(result.flaggedForRemoval).toBe(false);
+  });
+
+  it("adds tier-2 delta (0.03) for 4th confirmation (confirmedCount=4)", () => {
+    const result = adjustConfidence(0.5, "confirmed", 4);
+    expect(result.confidence).toBeCloseTo(0.53);
+    expect(result.flaggedForRemoval).toBe(false);
+  });
+
+  it("adds tier-3 delta (0.01) for 7th confirmation (confirmedCount=7)", () => {
+    const result = adjustConfidence(0.5, "confirmed", 7);
+    expect(result.confidence).toBeCloseTo(0.51);
+    expect(result.flaggedForRemoval).toBe(false);
+  });
+
+  it("defaults to tier-1 delta when confirmedCount is omitted", () => {
+    const result = adjustConfidence(0.5, "confirmed");
+    expect(result.confidence).toBeCloseTo(0.55);
   });
 
   it("subtracts 0.15 for contradicted outcome", () => {
@@ -67,7 +123,7 @@ describe("adjustConfidence", () => {
   });
 
   it("clamps at 0.9 maximum", () => {
-    const result = adjustConfidence(0.88, "confirmed");
+    const result = adjustConfidence(0.88, "confirmed", 0);
     expect(result.confidence).toBe(0.9);
     expect(result.flaggedForRemoval).toBe(false);
   });
@@ -93,7 +149,7 @@ describe("adjustConfidence", () => {
   });
 
   it("clamps at 0.9 for maximum boundary", () => {
-    const result = adjustConfidence(0.9, "confirmed");
+    const result = adjustConfidence(0.9, "confirmed", 0);
     expect(result.confidence).toBe(0.9);
     expect(result.flaggedForRemoval).toBe(false);
   });

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -21,9 +21,15 @@ const OBS_BRACKET_MED_MAX = 5;
 const OBS_BRACKET_HIGH_MAX = 10;
 
 // adjustConfidence deltas
-const DELTA_CONFIRMED = 0.05;
+// Confirmation uses diminishing returns to prevent runaway confidence on trivially easy-to-confirm instincts.
+const DELTA_CONFIRMED_TIER1 = 0.05; // 1st–3rd confirmation
+const DELTA_CONFIRMED_TIER2 = 0.03; // 4th–6th confirmation
+const DELTA_CONFIRMED_TIER3 = 0.01; // 7th+ confirmation
 const DELTA_CONTRADICTED = -0.15;
 const DELTA_INACTIVE = 0;
+
+const CONFIRMED_TIER1_MAX = 3;
+const CONFIRMED_TIER2_MAX = 6;
 
 // applyPassiveDecay
 // Increased from 0.02 to 0.05: at 0.5 confidence, reaches 0.1 in ~8 weeks instead of 20.
@@ -35,6 +41,16 @@ const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 // ---------------------------------------------------------------------------
 
 export type FeedbackOutcome = "confirmed" | "contradicted" | "inactive";
+
+/**
+ * Returns the confirmation confidence delta using diminishing returns.
+ * Higher confirmed_count yields smaller increments to prevent runaway scores.
+ */
+export function confirmationDelta(confirmedCount: number): number {
+  if (confirmedCount <= CONFIRMED_TIER1_MAX) return DELTA_CONFIRMED_TIER1;
+  if (confirmedCount <= CONFIRMED_TIER2_MAX) return DELTA_CONFIRMED_TIER2;
+  return DELTA_CONFIRMED_TIER3;
+}
 
 export interface ConfidenceResult {
   confidence: number;
@@ -71,18 +87,28 @@ export function initialConfidence(observationCount: number): number {
 
 /**
  * Adjusts confidence based on a feedback outcome from the observer loop.
+ * For "confirmed" outcomes, applies diminishing returns based on how many
+ * times the instinct has already been confirmed (higher count = smaller delta).
  * Returns the clamped confidence and a flag indicating if removal is warranted.
+ *
+ * @param current       - Current confidence value
+ * @param outcome       - Feedback outcome type
+ * @param confirmedCount - Current confirmed_count (used for diminishing returns on confirmations)
  */
 export function adjustConfidence(
   current: number,
   outcome: FeedbackOutcome,
+  confirmedCount = 0,
 ): ConfidenceResult {
-  const deltas: Record<FeedbackOutcome, number> = {
-    confirmed: DELTA_CONFIRMED,
-    contradicted: DELTA_CONTRADICTED,
-    inactive: DELTA_INACTIVE,
-  };
-  const raw = current + deltas[outcome];
+  let delta: number;
+  if (outcome === "confirmed") {
+    delta = confirmationDelta(confirmedCount);
+  } else if (outcome === "contradicted") {
+    delta = DELTA_CONTRADICTED;
+  } else {
+    delta = DELTA_INACTIVE;
+  }
+  const raw = current + delta;
   return toResult(raw);
 }
 

--- a/src/instinct-parser.ts
+++ b/src/instinct-parser.ts
@@ -132,6 +132,9 @@ export function parseInstinct(content: string): Instinct {
   if (fm["graduated_at"] !== undefined && fm["graduated_at"] !== null) {
     instinct.graduated_at = String(fm["graduated_at"]);
   }
+  if (fm["last_confirmed_session"] !== undefined && fm["last_confirmed_session"] !== null) {
+    instinct.last_confirmed_session = String(fm["last_confirmed_session"]);
+  }
 
   return instinct;
 }
@@ -176,6 +179,9 @@ export function serializeInstinct(instinct: Instinct): string {
   }
   if (instinct.graduated_at !== undefined) {
     frontmatter["graduated_at"] = instinct.graduated_at;
+  }
+  if (instinct.last_confirmed_session !== undefined) {
+    frontmatter["last_confirmed_session"] = instinct.last_confirmed_session;
   }
 
   const yamlStr = stringifyYaml(frontmatter);

--- a/src/prompts/analyzer-system-single-shot.ts
+++ b/src/prompts/analyzer-system-single-shot.ts
@@ -88,11 +88,50 @@ Each observation may include an active_instincts field listing instinct IDs
 that were injected into the agent's system prompt before that turn.
 
 Use this to update existing instinct confidence scores:
-- Confirmed (+0.05): instinct was active and agent followed guidance without correction
+- Confirmed: instinct was active, agent followed guidance, user did NOT correct
 - Contradicted (-0.15): instinct was active but user corrected the agent
 - Inactive (no change): instinct was injected but trigger never arose
 
-When updating, increment the corresponding count field and recalculate confidence.
+When updating, increment the corresponding count field.
+
+### Confirmation confidence deltas (diminishing returns)
+Do NOT apply a flat +0.05 for every confirmation. Use these tiers based on the
+instinct's current confirmed_count BEFORE this update:
+- 1st-3rd confirmation (confirmed_count 0-2):  +0.05
+- 4th-6th confirmation (confirmed_count 3-5):  +0.03
+- 7th+ confirmation   (confirmed_count 6+):    +0.01
+
+Note: the client applies these deltas automatically from confirmed_count.
+You should still set the correct confirmed_count so the client can compute it.
+
+### Per-session confirmation deduplication
+An instinct may only be confirmed ONCE per unique session_id. Each existing
+instinct includes a last_confirmed_session field (if it has been confirmed before).
+
+Rules:
+- If all observations showing this instinct active belong to the same session as
+  last_confirmed_session, do NOT increment confirmed_count. The instinct already
+  received credit for that session.
+- If a NEW session_id (different from last_confirmed_session) shows the instinct
+  active and followed, increment confirmed_count by 1 and set last_confirmed_session
+  to that new session_id.
+- When creating a new instinct with initial confirmed_count > 0, set
+  last_confirmed_session to the session_id that provided the confirmation.
+
+### Baseline behavior filtering
+Do NOT mark an instinct as "confirmed" if the agent's behavior would be expected
+baseline practice regardless of whether the instinct was injected.
+
+Examples of baseline behavior that should NOT count as confirmation:
+- Reading a file before editing it
+- Running a linter or type-checker after code changes
+- Using conventional commit message format
+- Checking for errors after tool calls
+- Clarifying ambiguous requirements before starting
+
+Only count a confirmation when the instinct guided behavior that would plausibly
+NOT have occurred without it (e.g., a project-specific workflow, a non-obvious
+convention, or a recovery pattern the agent had to learn).
 
 ## Confidence Scoring Rules
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface Instinct {
   flagged_for_removal?: boolean;
   graduated_to?: GraduationTarget;
   graduated_at?: string; // ISO 8601
+  last_confirmed_session?: string; // session ID that last provided a confirmation
 }
 
 export type GraduationTarget = "agents-md" | "skill" | "command";


### PR DESCRIPTION
Fixes #23

## Problem

The feedback loop had a structural confirmation bias - instincts like "read before edit" accumulated high confidence from behaviors that would have happened anyway, regardless of the instinct being injected.

## Three complementary fixes

### 1. Per-session confirmation deduplication

An instinct can only be confirmed **once per unique session_id**. Added `last_confirmed_session` to the `Instinct` type and `InstinctChangePayload`. Client-side enforcement in `buildInstinctFromChange()` reverts any `confirmed_count` increment where the confirming session matches `last_confirmed_session` (and holds confidence unchanged). The analyzer prompt is also updated with explicit per-session dedup rules.

### 2. Baseline behavior filtering

The analyzer prompt now explicitly lists behaviors that must **not** count as confirmations - reading a file before editing, running a linter, using conventional commits, etc. Only non-obvious or project-specific behaviors that plausibly wouldn't happen without the instinct are counted.

### 3. Diminishing returns on confirmation delta

Replaced flat +0.05 with tiered deltas based on `confirmed_count`:

| Confirmations | Delta |
|---|---|
| 1st-3rd (count 0-3) | +0.05 |
| 4th-6th (count 4-6) | +0.03 |
| 7th+ (count 7+) | +0.01 |

New `confirmationDelta(confirmedCount)` helper in `confidence.ts`. `adjustConfidence()` updated to accept an optional `confirmedCount` param. Client-side recomputation in `buildInstinctFromChange()` so we don't trust LLM arithmetic.

## Changes

- `src/types.ts` - `last_confirmed_session?: string` on `Instinct`
- `src/confidence.ts` - `confirmationDelta()` helper + updated `adjustConfidence()` signature
- `src/instinct-parser.ts` - parse/serialize `last_confirmed_session`
- `src/cli/analyze-single-shot.ts` - payload field, compact format inclusion, client-side enforcement
- `src/prompts/analyzer-system-single-shot.ts` - all three guidance sections
- `docs/internals.md` - confidence scoring section updated

## Tests

- 669 tests pass (added 28 new tests covering diminishing returns, session dedup, and compact format)
- All backward-compatible: `last_confirmed_session` is optional; instincts without it behave as before