### PR TITLE
feat: add analysis event log and user notification on instinct changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ pi-continuous-learning/
     active-instincts.ts     # Shared state for injected instinct IDs
     agents-md.ts            # AGENTS.md file reader
     error-logger.ts         # Structured logging
+    analysis-event-log.ts   # Append-only event log for analyzer -> extension notification
+    analysis-notification.ts # Extension-side notification check on before_agent_start
     instinct-status.ts      # /instinct-status command
     instinct-evolve.ts      # /instinct-evolve command (LLM-powered)
     instinct-export.ts      # /instinct-export command

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -61,6 +61,8 @@ All data lives under `~/.pi/continuous-learning/`. The extension creates this st
 | `*.jsonl` in archive | `appendObservation()` | JSONL | When `observations.jsonl` hits 10 MB |
 | `<id>.md` in instincts dirs | Standalone analyzer (via `instinct_write` tool) | YAML frontmatter + Markdown | Every analysis run |
 | `analyze.lock` | Standalone analyzer | JSON (`{pid, started_at}`) | While analyzer is running |
+| `analysis-events.jsonl` | Standalone analyzer | JSONL (one summary per run) | After each project analysis with changes |
+| `analysis-events.consumed` | Extension (transient) | JSONL | Briefly during atomic consume; deleted after read |
 
 ---
 
@@ -174,6 +176,9 @@ Haiku analyzes patterns, calls instinct_write/instinct_read tools
   |
   v
 session.dispose(), update last_analyzed_at in project.json
+  |
+  v
+appendAnalysisEvent()  -- write summary to analysis-events.jsonl for extension notification
   |
   v
 Release lockfile
@@ -401,6 +406,8 @@ index.ts (entry point)
   |   |-- command-scaffold.ts      -- generates command scaffolds from workflow clusters
   |   |-- agents-md.ts             -- reads and writes AGENTS.md files
   |-- instinct-projects.ts   -- /instinct-projects command
+  |-- analysis-notification.ts -- before_agent_start notification check
+  |   |-- analysis-event-log.ts    -- read + consume analysis events
 ```
 
 ### Standalone Analyzer (`src/cli/analyze.ts`)
@@ -416,6 +423,7 @@ cli/analyze.ts (entry point, run via cron)
   |   |-- confidence.ts                  -- pure confidence math
   |-- instinct-store.ts                  -- CRUD for instinct files
   |-- agents-md.ts                       -- AGENTS.md reader
+  |-- analysis-event-log.ts              -- append analysis events for extension notification
   |-- cli/analyze-single-shot.ts         -- single-shot core: parseChanges, buildInstinctFromChange,
   |                                         formatInstinctsCompact, estimateTokens
   |-- prompts/analyzer-system-single-shot.ts  -- system prompt
@@ -560,10 +568,59 @@ These fields are:
 
 ---
 
+## Analysis Event Log and Notifications
+
+The background analyzer writes a summary of instinct changes after each project analysis. The extension reads these summaries and displays a brief notification when the user starts a new prompt.
+
+### Event Log Format
+
+Each project has an `analysis-events.jsonl` file under its project directory. Each line is a JSON object:
+
+```json
+{
+  "timestamp": "2026-03-27T15:00:00Z",
+  "project_id": "a1b2c3d4e5f6",
+  "project_name": "my-app",
+  "created": [{"id": "use-result-type", "title": "Use Result type", "scope": "project", "trigger": "...", "action": "..."}],
+  "updated": [{"id": "read-before-edit", "title": "Read Before Edit", "scope": "global", "confidence_delta": 0.05}],
+  "deleted": []
+}
+```
+
+Events are only written when at least one change occurred (no-op runs produce no events).
+
+### Concurrency: Atomic Rename Pattern
+
+Multiple analyzer runs may write events before a Pi session reads them. The consume operation uses an atomic rename to prevent data loss:
+
+1. **Analyzer writes**: `appendFileSync` to `analysis-events.jsonl` (append-only, creates if missing)
+2. **Extension reads**: On `before_agent_start`, calls `consumeAnalysisEvents()` which:
+   a. Checks for orphaned `.consumed` file from a prior crash - reads it first
+   b. Atomically renames `analysis-events.jsonl` to `analysis-events.consumed` (POSIX rename is atomic)
+   c. Reads all lines from `.consumed`
+   d. Deletes `.consumed`
+
+This is safe because:
+- If the analyzer has the file open during rename, writes follow the inode (go to `.consumed`), so the extension gets that data too
+- New analyzer writes after the rename create a fresh `analysis-events.jsonl`
+- If the extension crashes between rename and delete, the orphaned `.consumed` is recovered on the next consume call
+
+### Notification Display
+
+The extension calls `checkAnalysisNotifications()` on every `before_agent_start`. If events exist, a one-line notification is shown via `ctx.ui.notify()`:
+
+```
+[instincts] Background analysis: +1 new (use-result-type), 2 updated, 0 deleted
+```
+
+Created instinct IDs are listed (up to 3, then `...`). The notification is brief and non-intrusive.
+
+---
+
 ## Session Lifecycle
 
 1. **`session_start`**: Load config, detect project, create storage dirs, clean old archives, load installed skills, register LLM tools.
-2. **`before_agent_start`** (each turn): Record user prompt observation, load and inject instincts into system prompt, store injected IDs in shared state.
+2. **`before_agent_start`** (each turn): Record user prompt observation, check for analysis notifications (consume events, show summary), load and inject instincts into system prompt, store injected IDs in shared state.
 3. **`tool_execution_start`** / **`tool_execution_end`** (each tool call): Record tool observations with scrubbed inputs/outputs and active instinct IDs.
 4. **`agent_end`** (each turn): Record agent end observation, clear active instincts state.
 5. **`session_shutdown`**: No cleanup needed (analyzer runs externally).

--- a/src/analysis-event-log.test.ts
+++ b/src/analysis-event-log.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdirSync, mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  appendAnalysisEvent,
+  consumeAnalysisEvents,
+  getEventsPath,
+  getConsumedPath,
+  type AnalysisEvent,
+} from "./analysis-event-log.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "analysis-event-log-test-"));
+}
+
+function makeProjectDir(baseDir: string, projectId: string): void {
+  mkdirSync(join(baseDir, "projects", projectId), { recursive: true });
+}
+
+function makeEvent(overrides: Partial<AnalysisEvent> = {}): AnalysisEvent {
+  return {
+    timestamp: "2026-03-27T15:00:00Z",
+    project_id: "proj-1",
+    project_name: "my-app",
+    created: [],
+    updated: [],
+    deleted: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("analysis-event-log", () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = makeTmpDir();
+    makeProjectDir(baseDir, "proj-1");
+  });
+
+  describe("appendAnalysisEvent", () => {
+    it("skips writing when all change arrays are empty", () => {
+      const event = makeEvent();
+      appendAnalysisEvent(event, baseDir);
+
+      expect(existsSync(getEventsPath("proj-1", baseDir))).toBe(false);
+    });
+
+    it("writes a single event as one JSONL line", () => {
+      const event = makeEvent({
+        created: [{ id: "use-result-type", title: "Use Result type", scope: "project" }],
+      });
+      appendAnalysisEvent(event, baseDir);
+
+      const content = readFileSync(getEventsPath("proj-1", baseDir), "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines).toHaveLength(1);
+
+      const parsed = JSON.parse(lines[0]!);
+      expect(parsed.project_id).toBe("proj-1");
+      expect(parsed.created).toHaveLength(1);
+      expect(parsed.created[0].id).toBe("use-result-type");
+    });
+
+    it("appends multiple events across calls", () => {
+      const event1 = makeEvent({
+        created: [{ id: "instinct-a", title: "A", scope: "project" }],
+      });
+      const event2 = makeEvent({
+        timestamp: "2026-03-27T16:00:00Z",
+        updated: [{ id: "instinct-b", title: "B", scope: "global", confidence_delta: 0.05 }],
+      });
+
+      appendAnalysisEvent(event1, baseDir);
+      appendAnalysisEvent(event2, baseDir);
+
+      const content = readFileSync(getEventsPath("proj-1", baseDir), "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines).toHaveLength(2);
+    });
+
+    it("creates parent directories if needed", () => {
+      const event = makeEvent({
+        project_id: "proj-new",
+        deleted: [{ id: "old-instinct", title: "Old", scope: "project" }],
+      });
+      // proj-new dir doesn't exist yet
+      appendAnalysisEvent(event, baseDir);
+
+      expect(existsSync(getEventsPath("proj-new", baseDir))).toBe(true);
+    });
+  });
+
+  describe("consumeAnalysisEvents", () => {
+    it("returns empty array when no events file exists", () => {
+      const events = consumeAnalysisEvents("proj-1", baseDir);
+      expect(events).toEqual([]);
+    });
+
+    it("returns all events and deletes the file", () => {
+      const event1 = makeEvent({
+        created: [{ id: "a", title: "A", scope: "project" }],
+      });
+      const event2 = makeEvent({
+        updated: [{ id: "b", title: "B", scope: "global", confidence_delta: 0.1 }],
+      });
+
+      appendAnalysisEvent(event1, baseDir);
+      appendAnalysisEvent(event2, baseDir);
+
+      const events = consumeAnalysisEvents("proj-1", baseDir);
+      expect(events).toHaveLength(2);
+      expect(events[0]!.created).toHaveLength(1);
+      expect(events[1]!.updated).toHaveLength(1);
+
+      // Files should be cleaned up
+      expect(existsSync(getEventsPath("proj-1", baseDir))).toBe(false);
+      expect(existsSync(getConsumedPath("proj-1", baseDir))).toBe(false);
+    });
+
+    it("returns empty array on second consume (idempotent)", () => {
+      appendAnalysisEvent(
+        makeEvent({ created: [{ id: "a", title: "A", scope: "project" }] }),
+        baseDir
+      );
+
+      const first = consumeAnalysisEvents("proj-1", baseDir);
+      expect(first).toHaveLength(1);
+
+      const second = consumeAnalysisEvents("proj-1", baseDir);
+      expect(second).toEqual([]);
+    });
+
+    it("recovers orphaned consumed file from prior crash", () => {
+      // Simulate: extension renamed file but crashed before deleting .consumed
+      const consumedPath = getConsumedPath("proj-1", baseDir);
+      const orphanedEvent = makeEvent({
+        created: [{ id: "orphan", title: "Orphan", scope: "project" }],
+      });
+      writeFileSync(consumedPath, JSON.stringify(orphanedEvent) + "\n", "utf-8");
+
+      // Also write a new event to the main file
+      appendAnalysisEvent(
+        makeEvent({ updated: [{ id: "new", title: "New", scope: "global", confidence_delta: 0.05 }] }),
+        baseDir
+      );
+
+      const events = consumeAnalysisEvents("proj-1", baseDir);
+      expect(events).toHaveLength(2);
+      // Orphaned event comes first
+      expect(events[0]!.created[0]!.id).toBe("orphan");
+      expect(events[1]!.updated[0]!.id).toBe("new");
+
+      // Both files cleaned up
+      expect(existsSync(getEventsPath("proj-1", baseDir))).toBe(false);
+      expect(existsSync(getConsumedPath("proj-1", baseDir))).toBe(false);
+    });
+
+    it("recovers orphaned consumed file even when no new events exist", () => {
+      const consumedPath = getConsumedPath("proj-1", baseDir);
+      writeFileSync(
+        consumedPath,
+        JSON.stringify(makeEvent({ deleted: [{ id: "x", title: "X", scope: "project" }] })) + "\n",
+        "utf-8"
+      );
+
+      const events = consumeAnalysisEvents("proj-1", baseDir);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.deleted[0]!.id).toBe("x");
+    });
+
+    it("skips malformed lines without losing valid events", () => {
+      const eventsPath = getEventsPath("proj-1", baseDir);
+      const validEvent = makeEvent({
+        created: [{ id: "valid", title: "Valid", scope: "project" }],
+      });
+      writeFileSync(
+        eventsPath,
+        `not-json\n${JSON.stringify(validEvent)}\n{broken\n`,
+        "utf-8"
+      );
+
+      const events = consumeAnalysisEvents("proj-1", baseDir);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.created[0]!.id).toBe("valid");
+    });
+  });
+});

--- a/src/analysis-event-log.ts
+++ b/src/analysis-event-log.ts
@@ -1,0 +1,171 @@
+/**
+ * Append-only analysis event log with atomic rename for safe consumption.
+ *
+ * The background analyzer appends events to `analysis-events.jsonl`.
+ * The extension consumes events by atomically renaming the file to
+ * `.consumed`, reading it, then deleting it. On POSIX, rename is atomic -
+ * any in-flight appends follow the inode to the renamed file.
+ *
+ * Multiple analyzer runs can append before the extension reads. No events
+ * are lost because each run only appends; the file is never truncated by
+ * the analyzer.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { getProjectDir } from "./storage.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EVENTS_FILENAME = "analysis-events.jsonl";
+const CONSUMED_FILENAME = "analysis-events.consumed";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InstinctChangeSummary {
+  readonly id: string;
+  readonly title: string;
+  readonly scope: "project" | "global";
+  readonly trigger?: string;
+  readonly action?: string;
+  readonly confidence_delta?: number;
+}
+
+export interface AnalysisEvent {
+  readonly timestamp: string;
+  readonly project_id: string;
+  readonly project_name: string;
+  readonly created: readonly InstinctChangeSummary[];
+  readonly updated: readonly InstinctChangeSummary[];
+  readonly deleted: readonly InstinctChangeSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+export function getEventsPath(projectId: string, baseDir?: string): string {
+  return join(getProjectDir(projectId, baseDir), EVENTS_FILENAME);
+}
+
+export function getConsumedPath(projectId: string, baseDir?: string): string {
+  return join(getProjectDir(projectId, baseDir), CONSUMED_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Write (analyzer side)
+// ---------------------------------------------------------------------------
+
+/**
+ * Appends an analysis event to the project's event log.
+ * Skips writing if nothing changed (all arrays empty).
+ * Creates the parent directory if needed.
+ */
+export function appendAnalysisEvent(event: AnalysisEvent, baseDir?: string): void {
+  if (
+    event.created.length === 0 &&
+    event.updated.length === 0 &&
+    event.deleted.length === 0
+  ) {
+    return;
+  }
+
+  const eventsPath = getEventsPath(event.project_id, baseDir);
+  mkdirSync(dirname(eventsPath), { recursive: true });
+  appendFileSync(eventsPath, JSON.stringify(event) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Read and clear (extension side)
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically consumes all pending analysis events for a project.
+ *
+ * Strategy:
+ * 1. Check for orphaned `.consumed` file from a prior crash - read it first
+ * 2. Rename `analysis-events.jsonl` to `.consumed` (atomic on POSIX)
+ * 3. Read and parse all lines from `.consumed`
+ * 4. Delete `.consumed`
+ *
+ * Returns an empty array if no events exist or rename fails (e.g. file
+ * doesn't exist, or another consumer raced us).
+ */
+export function consumeAnalysisEvents(
+  projectId: string,
+  baseDir?: string
+): readonly AnalysisEvent[] {
+  const eventsPath = getEventsPath(projectId, baseDir);
+  const consumedPath = getConsumedPath(projectId, baseDir);
+
+  const allEvents: AnalysisEvent[] = [];
+
+  // Step 1: recover orphaned consumed file from prior crash
+  if (existsSync(consumedPath)) {
+    allEvents.push(...parseEventsFile(consumedPath));
+    safeUnlink(consumedPath);
+  }
+
+  // Step 2: atomically rename the events file
+  if (existsSync(eventsPath)) {
+    try {
+      renameSync(eventsPath, consumedPath);
+    } catch {
+      // Rename failed (race with another consumer, or OS issue).
+      // Return whatever we recovered from step 1.
+      return allEvents;
+    }
+
+    // Step 3: read the renamed file
+    allEvents.push(...parseEventsFile(consumedPath));
+
+    // Step 4: delete consumed file
+    safeUnlink(consumedPath);
+  }
+
+  return allEvents;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseEventsFile(filePath: string): AnalysisEvent[] {
+  const events: AnalysisEvent[] = [];
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n").filter((line) => line.trim().length > 0);
+
+    for (const line of lines) {
+      try {
+        events.push(JSON.parse(line) as AnalysisEvent);
+      } catch {
+        // Skip malformed lines - don't lose other events
+      }
+    }
+  } catch {
+    // File read failed - return empty
+  }
+
+  return events;
+}
+
+function safeUnlink(filePath: string): void {
+  try {
+    if (existsSync(filePath)) unlinkSync(filePath);
+  } catch {
+    // Best effort cleanup
+  }
+}

--- a/src/analysis-notification.test.ts
+++ b/src/analysis-notification.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { formatNotification, checkAnalysisNotifications } from "./analysis-notification.js";
+import { appendAnalysisEvent, type AnalysisEvent } from "./analysis-event-log.js";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<AnalysisEvent> = {}): AnalysisEvent {
+  return {
+    timestamp: "2026-03-27T15:00:00Z",
+    project_id: "proj-1",
+    project_name: "my-app",
+    created: [],
+    updated: [],
+    deleted: [],
+    ...overrides,
+  };
+}
+
+function makeMockCtx(): ExtensionContext {
+  return {
+    ui: {
+      notify: vi.fn(),
+      select: vi.fn(),
+      confirm: vi.fn(),
+      input: vi.fn(),
+      onTerminalInput: vi.fn(),
+      setStatus: vi.fn(),
+      setWorkingMessage: vi.fn(),
+      setWidget: vi.fn(),
+      setFooter: vi.fn(),
+      setHeader: vi.fn(),
+      setTitle: vi.fn(),
+      custom: vi.fn(),
+      pasteToEditor: vi.fn(),
+      setEditorText: vi.fn(),
+      getEditorText: vi.fn(),
+      editor: vi.fn(),
+      setEditorComponent: vi.fn(),
+      theme: {} as ExtensionContext["ui"]["theme"],
+      getAllThemes: vi.fn(),
+      getTheme: vi.fn(),
+      setTheme: vi.fn(),
+      getToolsExpanded: vi.fn(),
+      setToolsExpanded: vi.fn(),
+    },
+    hasUI: true,
+    cwd: "/tmp",
+    sessionManager: { getSessionId: vi.fn().mockReturnValue("session-1") } as unknown as ExtensionContext["sessionManager"],
+    modelRegistry: {} as unknown as ExtensionContext["modelRegistry"],
+    model: undefined,
+    isIdle: vi.fn(),
+    abort: vi.fn(),
+    hasPendingMessages: vi.fn(),
+    shutdown: vi.fn(),
+    getContextUsage: vi.fn(),
+    compact: vi.fn(),
+    getSystemPrompt: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatNotification
+// ---------------------------------------------------------------------------
+
+describe("formatNotification", () => {
+  it("returns null for empty events array", () => {
+    expect(formatNotification([])).toBeNull();
+  });
+
+  it("returns null when all change arrays are empty", () => {
+    expect(formatNotification([makeEvent()])).toBeNull();
+  });
+
+  it("formats created instincts with IDs", () => {
+    const events = [
+      makeEvent({
+        created: [
+          { id: "use-result-type", title: "Use Result type", scope: "project" },
+        ],
+      }),
+    ];
+    const result = formatNotification(events);
+    expect(result).toBe("[instincts] Background analysis: +1 new (use-result-type)");
+  });
+
+  it("formats multiple change types", () => {
+    const events = [
+      makeEvent({
+        created: [{ id: "a", title: "A", scope: "project" }],
+        updated: [
+          { id: "b", title: "B", scope: "global", confidence_delta: 0.05 },
+          { id: "c", title: "C", scope: "project", confidence_delta: -0.1 },
+        ],
+        deleted: [{ id: "d", title: "D", scope: "project" }],
+      }),
+    ];
+    const result = formatNotification(events);
+    expect(result).toBe(
+      "[instincts] Background analysis: +1 new (a), 2 updated, 1 deleted"
+    );
+  });
+
+  it("aggregates across multiple events", () => {
+    const events = [
+      makeEvent({
+        created: [{ id: "x", title: "X", scope: "project" }],
+      }),
+      makeEvent({
+        created: [{ id: "y", title: "Y", scope: "global" }],
+        updated: [{ id: "z", title: "Z", scope: "project", confidence_delta: 0.1 }],
+      }),
+    ];
+    const result = formatNotification(events);
+    expect(result).toBe(
+      "[instincts] Background analysis: +2 new (x, y), 1 updated"
+    );
+  });
+
+  it("truncates created IDs list beyond 3", () => {
+    const events = [
+      makeEvent({
+        created: [
+          { id: "a", title: "A", scope: "project" },
+          { id: "b", title: "B", scope: "project" },
+          { id: "c", title: "C", scope: "project" },
+          { id: "d", title: "D", scope: "project" },
+        ],
+      }),
+    ];
+    const result = formatNotification(events);
+    expect(result).toBe(
+      "[instincts] Background analysis: +4 new (a, b, c, ...)"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAnalysisNotifications
+// ---------------------------------------------------------------------------
+
+describe("checkAnalysisNotifications", () => {
+  let baseDir: string;
+  let ctx: ExtensionContext;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), "analysis-notif-test-"));
+    mkdirSync(join(baseDir, "projects", "proj-1"), { recursive: true });
+    ctx = makeMockCtx();
+  });
+
+  it("does nothing when projectId is null", () => {
+    checkAnalysisNotifications(ctx, null, baseDir);
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no events exist", () => {
+    checkAnalysisNotifications(ctx, "proj-1", baseDir);
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("shows notification and consumes events", () => {
+    appendAnalysisEvent(
+      makeEvent({
+        created: [{ id: "new-instinct", title: "New instinct", scope: "project" }],
+      }),
+      baseDir
+    );
+
+    checkAnalysisNotifications(ctx, "proj-1", baseDir);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "[instincts] Background analysis: +1 new (new-instinct)",
+      "info"
+    );
+
+    // Second call should not notify (events consumed)
+    checkAnalysisNotifications(ctx, "proj-1", baseDir);
+    expect(ctx.ui.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("aggregates events from multiple analyzer runs", () => {
+    appendAnalysisEvent(
+      makeEvent({
+        created: [{ id: "a", title: "A", scope: "project" }],
+      }),
+      baseDir
+    );
+    appendAnalysisEvent(
+      makeEvent({
+        updated: [{ id: "b", title: "B", scope: "global", confidence_delta: 0.05 }],
+        deleted: [{ id: "c", title: "C", scope: "project" }],
+      }),
+      baseDir
+    );
+
+    checkAnalysisNotifications(ctx, "proj-1", baseDir);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "[instincts] Background analysis: +1 new (a), 1 updated, 1 deleted",
+      "info"
+    );
+  });
+});

--- a/src/analysis-notification.ts
+++ b/src/analysis-notification.ts
@@ -1,0 +1,79 @@
+/**
+ * Extension-side notification for analysis events.
+ *
+ * On `before_agent_start`, consumes pending analysis events and shows
+ * a brief one-line notification summarizing instinct changes since the
+ * last session interaction.
+ */
+
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  consumeAnalysisEvents,
+  type AnalysisEvent,
+} from "./analysis-event-log.js";
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregates multiple analysis events into a single summary line.
+ * Returns null when no changes occurred.
+ */
+export function formatNotification(events: readonly AnalysisEvent[]): string | null {
+  if (events.length === 0) return null;
+
+  let created = 0;
+  let updated = 0;
+  let deleted = 0;
+  const createdIds: string[] = [];
+
+  for (const event of events) {
+    created += event.created.length;
+    updated += event.updated.length;
+    deleted += event.deleted.length;
+    for (const c of event.created) {
+      createdIds.push(c.id);
+    }
+  }
+
+  if (created === 0 && updated === 0 && deleted === 0) return null;
+
+  const parts: string[] = [];
+  if (created > 0) {
+    const idList = createdIds.slice(0, 3).join(", ");
+    const suffix = createdIds.length > 3 ? ", ..." : "";
+    parts.push(`+${created} new (${idList}${suffix})`);
+  }
+  if (updated > 0) {
+    parts.push(`${updated} updated`);
+  }
+  if (deleted > 0) {
+    parts.push(`${deleted} deleted`);
+  }
+
+  return `[instincts] Background analysis: ${parts.join(", ")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks for pending analysis events and shows a notification if any exist.
+ * Safe to call on every `before_agent_start` - no-ops when there's nothing.
+ */
+export function checkAnalysisNotifications(
+  ctx: ExtensionContext,
+  projectId: string | null,
+  baseDir?: string
+): void {
+  if (!projectId) return;
+
+  const events = consumeAnalysisEvents(projectId, baseDir);
+  const message = formatNotification(events);
+
+  if (message) {
+    ctx.ui.notify(message, "info");
+  }
+}

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -34,6 +34,11 @@ import {
 } from "./analyze-single-shot.js";
 import { isLowSignalBatch } from "../observation-signal.js";
 import {
+  appendAnalysisEvent,
+  type InstinctChangeSummary,
+  type AnalysisEvent,
+} from "../analysis-event-log.js";
+import {
   loadProjectInstincts,
   loadGlobalInstincts,
   saveInstinct,
@@ -321,6 +326,9 @@ async function analyzeProject(
   const timeoutHandle = setTimeout(() => abortController.abort(), timeoutMs);
 
   const instinctCounts = { created: 0, updated: 0, deleted: 0 };
+  const createdSummaries: InstinctChangeSummary[] = [];
+  const updatedSummaries: InstinctChangeSummary[] = [];
+  const deletedSummaries: InstinctChangeSummary[] = [];
   const projectInstinctsDir = getProjectInstinctsDir(project.id, "personal", baseDir);
   const globalInstinctsDir = getGlobalInstinctsDir("personal", baseDir);
 
@@ -342,6 +350,11 @@ async function analyzeProject(
         if (existsSync(filePath)) {
           unlinkSync(filePath);
           instinctCounts.deleted++;
+          deletedSummaries.push({
+            id,
+            title: id,
+            scope: change.scope ?? "project",
+          });
         }
       } else if (change.action === "create") {
         if (createsRemaining <= 0) continue; // rate limit reached
@@ -353,6 +366,13 @@ async function analyzeProject(
         saveInstinct(instinct, dir);
         instinctCounts.created++;
         createsRemaining--;
+        createdSummaries.push({
+          id: instinct.id,
+          title: instinct.title,
+          scope: instinct.scope,
+          trigger: instinct.trigger,
+          action: instinct.action,
+        });
       } else {
         // update
         const existing = allInstincts.find((i) => i.id === change.instinct?.id) ?? null;
@@ -362,6 +382,15 @@ async function analyzeProject(
         const dir = instinct.scope === "global" ? globalInstinctsDir : projectInstinctsDir;
         saveInstinct(instinct, dir);
         instinctCounts.updated++;
+        const delta = existing
+          ? instinct.confidence - existing.confidence
+          : undefined;
+        updatedSummaries.push({
+          id: instinct.id,
+          title: instinct.title,
+          scope: instinct.scope,
+          ...(delta !== undefined ? { confidence_delta: delta } : {}),
+        });
       }
     }
   } finally {
@@ -390,6 +419,17 @@ async function analyzeProject(
   };
 
   logger.projectComplete(stats);
+
+  // Write analysis event for extension notification
+  const analysisEvent: AnalysisEvent = {
+    timestamp: new Date().toISOString(),
+    project_id: project.id,
+    project_name: project.name,
+    created: createdSummaries,
+    updated: updatedSummaries,
+    deleted: deletedSummaries,
+  };
+  appendAnalysisEvent(analysisEvent, baseDir);
 
   saveProjectMeta(
     project.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { handleInstinctProjects, COMMAND_NAME as PROJECTS_CMD } from "./instinct
 import { handleInstinctGraduate, COMMAND_NAME as GRADUATE_CMD } from "./instinct-graduate.js";
 import { registerAllTools } from "./instinct-tools.js";
 import { logError } from "./error-logger.js";
+import { checkAnalysisNotifications } from "./analysis-notification.js";
 import type { Config, InstalledSkill, ProjectEntry } from "./types.js";
 
 export default function (pi: ExtensionAPI): void {
@@ -70,6 +71,7 @@ export default function (pi: ExtensionAPI): void {
     try {
       if (!project || !config) return;
       handleBeforeAgentStart(event, ctx, project);
+      checkAnalysisNotifications(ctx, project.id);
       return handleBeforeAgentStartInjection(event, ctx, config, project.id) ?? undefined;
     } catch (err) {
       logError(project?.id ?? null, "before_agent_start", err);


### PR DESCRIPTION
## Summary

The background analyzer now writes a summary of instinct changes to an append-only event log after each project analysis. The extension consumes these events on `before_agent_start` and shows a brief one-line notification via `ctx.ui.notify()`.

Example notification:
```
[instincts] Background analysis: +2 new (use-result-type, prefer-const), 1 updated, 0 deleted
```

## Concurrency Strategy

Uses the **atomic rename pattern** to handle multiple analyzer runs before a session reads, and to protect against concurrent modification:

1. Analyzer appends to `analysis-events.jsonl` (append-only, creates if missing)
2. Extension atomically renames to `.consumed`, reads it, deletes it
3. POSIX `rename()` is atomic - in-flight appends follow the inode to the renamed file
4. Orphaned `.consumed` files from a prior crash are recovered on the next consume call

## New Modules

- `src/analysis-event-log.ts` - append/consume API with atomic rename
- `src/analysis-notification.ts` - format and display notification on `before_agent_start`

## Modified

- `src/cli/analyze.ts` - writes analysis events after each project run
- `src/index.ts` - calls notification check on `before_agent_start`
- `docs/internals.md` - documents event log format, concurrency, and notification
- `AGENTS.md` - updated directory structure

## Tests

20 new tests covering event writing, consumption, idempotency, orphan recovery, malformed line handling, formatting, aggregation, and end-to-end notification flow. All 689 tests pass.

Closes #22