### PR TITLE
feat: cross-session recurring prompt detection

### DIFF
--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -40,7 +40,14 @@ import {
   buildInstinctFromChange,
   estimateTokens,
 } from "./analyze-single-shot.js";
-import { isLowSignalBatch } from "../observation-signal.js";
+import { isLowSignalBatch, type FrequencyBoostContext } from "../observation-signal.js";
+import {
+  loadProjectFrequencyTable,
+  saveProjectFrequencyTable,
+  loadGlobalFrequencyTable,
+  saveGlobalFrequencyTable,
+  updateFrequencyTablesFromLines,
+} from "../prompt-frequency.js";
 import {
   appendAnalysisEvent,
   type InstinctChangeSummary,
@@ -217,7 +224,22 @@ async function analyzeProject(
     return { ran: false, skippedReason: "no new observation lines after preprocessing" };
   }
 
-  if (isLowSignalBatch(newObsLines)) {
+  // Update prompt frequency tables before signal check so counts accumulate
+  // even when batches are skipped as low-signal.
+  const projectFreqTable = loadProjectFrequencyTable(project.id, baseDir);
+  const globalFreqTable = loadGlobalFrequencyTable(baseDir);
+  const { project: updatedProjectFreq, global: updatedGlobalFreq } =
+    updateFrequencyTablesFromLines(newObsLines, projectFreqTable, globalFreqTable);
+  saveProjectFrequencyTable(updatedProjectFreq, project.id, baseDir);
+  saveGlobalFrequencyTable(updatedGlobalFreq, baseDir);
+
+  const freqContext: FrequencyBoostContext = {
+    projectFrequency: updatedProjectFreq,
+    minSessions: config.recurring_prompt_min_sessions,
+    scoreBoost: config.recurring_prompt_score_boost,
+  };
+
+  if (isLowSignalBatch(newObsLines, freqContext)) {
     return { ran: false, skippedReason: "low-signal batch (no errors, corrections, or user redirections)" };
   }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -100,6 +100,23 @@ describe("loadConfig", () => {
     expect(DEFAULT_CONFIG.instinct_ttl_days).toBe(28);
   });
 
+  it("has correct recurring prompt detection defaults", () => {
+    expect(DEFAULT_CONFIG.recurring_prompt_min_sessions).toBe(3);
+    expect(DEFAULT_CONFIG.recurring_prompt_score_boost).toBe(3);
+  });
+
+  it("merges recurring prompt config overrides", () => {
+    const partial = { recurring_prompt_min_sessions: 5, recurring_prompt_score_boost: 5 };
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify(partial) as unknown as ReturnType<typeof fs.readFileSync>);
+
+    const config = loadConfig();
+
+    expect(config.recurring_prompt_min_sessions).toBe(5);
+    expect(config.recurring_prompt_score_boost).toBe(5);
+    expect(config.run_interval_minutes).toBe(DEFAULT_CONFIG.run_interval_minutes);
+  });
+
   it("exports CONFIG_PATH pointing to ~/.pi/continuous-learning/config.json", () => {
     const expected = path.join(os.homedir(), ".pi", "continuous-learning", "config.json");
     expect(CONFIG_PATH).toBe(expected);

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,8 @@ export const DEFAULT_CONFIG: Config = {
   dreaming_enabled: true,
   consolidation_interval_days: DEFAULT_CONSOLIDATION_INTERVAL_DAYS,
   consolidation_min_sessions: DEFAULT_CONSOLIDATION_MIN_SESSIONS,
+  recurring_prompt_min_sessions: 3,
+  recurring_prompt_score_boost: 3,
 };
 
 // ---------------------------------------------------------------------------
@@ -118,6 +120,8 @@ const PartialConfigSchema = Type.Partial(
     dreaming_enabled: Type.Boolean(),
     consolidation_interval_days: Type.Number(),
     consolidation_min_sessions: Type.Number(),
+    recurring_prompt_min_sessions: Type.Number(),
+    recurring_prompt_score_boost: Type.Number(),
   })
 );
 

--- a/src/instinct-injector.test.ts
+++ b/src/instinct-injector.test.ts
@@ -61,6 +61,8 @@ const BASE_CONFIG: Config = {
   dreaming_enabled: true,
   consolidation_interval_days: 7,
   consolidation_min_sessions: 10,
+  recurring_prompt_min_sessions: 3,
+  recurring_prompt_score_boost: 3,
 };
 
 const MOCK_CTX = {} as ExtensionContext;

--- a/src/instinct-loader.test.ts
+++ b/src/instinct-loader.test.ts
@@ -54,6 +54,8 @@ const BASE_CONFIG: Config = {
   dreaming_enabled: true,
   consolidation_interval_days: 7,
   consolidation_min_sessions: 10,
+  recurring_prompt_min_sessions: 3,
+  recurring_prompt_score_boost: 3,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/observation-signal.test.ts
+++ b/src/observation-signal.test.ts
@@ -3,8 +3,10 @@ import {
   scoreObservationBatch,
   isLowSignalBatch,
   LOW_SIGNAL_THRESHOLD,
+  type FrequencyBoostContext,
 } from "./observation-signal.js";
-import type { Observation } from "./types.js";
+import type { Observation, PromptFrequencyTable } from "./types.js";
+import { normalizePrompt, hashPrompt } from "./prompt-frequency.js";
 
 const base: Omit<Observation, "event"> = {
   timestamp: "2026-01-01T00:00:00.000Z",
@@ -120,5 +122,81 @@ describe("isLowSignalBatch", () => {
 
   it(`LOW_SIGNAL_THRESHOLD is ${LOW_SIGNAL_THRESHOLD}`, () => {
     expect(LOW_SIGNAL_THRESHOLD).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Frequency boost
+// ---------------------------------------------------------------------------
+
+function makeFreqContext(
+  prompts: Record<string, number>,
+  minSessions = 3,
+  scoreBoost = 3
+): FrequencyBoostContext {
+  const projectFrequency: PromptFrequencyTable = {};
+  for (const [text, sessionCount] of Object.entries(prompts)) {
+    const key = hashPrompt(normalizePrompt(text));
+    projectFrequency[key] = {
+      count: sessionCount,
+      sessions: Array.from({ length: sessionCount }, (_, i) => `sess-${i + 1}`),
+      last_text: text,
+      first_seen: "2026-01-01T00:00:00Z",
+      last_seen: "2026-03-27T00:00:00Z",
+    };
+  }
+  return { projectFrequency, minSessions, scoreBoost };
+}
+
+describe("scoreObservationBatch with frequency boost", () => {
+  it("boosts score for recurring prompt (>= minSessions)", () => {
+    const ctx = makeFreqContext({ "PR it": 5 });
+    const lines = [line({ event: "user_prompt", input: "PR it" })];
+    const result = scoreObservationBatch(lines, ctx);
+    expect(result.score).toBe(4); // 1 (user_prompt) + 3 (boost)
+    expect(result.recurringPrompts).toBe(1);
+  });
+
+  it("does not boost for non-recurring prompt (< minSessions)", () => {
+    const ctx = makeFreqContext({ "PR it": 2 });
+    const lines = [line({ event: "user_prompt", input: "PR it" })];
+    const result = scoreObservationBatch(lines, ctx);
+    expect(result.score).toBe(1);
+    expect(result.recurringPrompts).toBe(0);
+  });
+
+  it("boosts multiple recurring prompts in same batch", () => {
+    const ctx = makeFreqContext({ "PR it": 3, "ship it": 4 });
+    const lines = [
+      line({ event: "user_prompt", input: "PR it" }),
+      line({ event: "user_prompt", input: "ship it" }),
+    ];
+    const result = scoreObservationBatch(lines, ctx);
+    expect(result.score).toBe(8); // 1+3 + 1+3
+    expect(result.recurringPrompts).toBe(2);
+  });
+
+  it("returns recurringPrompts=0 when no freqContext provided", () => {
+    const lines = [line({ event: "user_prompt", input: "PR it" })];
+    const result = scoreObservationBatch(lines);
+    expect(result.score).toBe(1);
+    expect(result.recurringPrompts).toBe(0);
+  });
+
+  it("normalizes prompt before lookup (case, whitespace, punctuation)", () => {
+    const ctx = makeFreqContext({ "pr it": 3 }); // normalized form
+    const lines = [line({ event: "user_prompt", input: "  PR  It!  " })];
+    const result = scoreObservationBatch(lines, ctx);
+    expect(result.recurringPrompts).toBe(1);
+  });
+});
+
+describe("isLowSignalBatch with frequency boost", () => {
+  it("returns false when boost pushes score past threshold", () => {
+    const ctx = makeFreqContext({ "PR it": 3 });
+    const lines = [line({ event: "user_prompt", input: "PR it" })];
+    // Without boost: score=1, below threshold. With boost: score=4.
+    expect(isLowSignalBatch(lines)).toBe(true);
+    expect(isLowSignalBatch(lines, ctx)).toBe(false);
   });
 });

--- a/src/observation-signal.ts
+++ b/src/observation-signal.ts
@@ -4,37 +4,34 @@
  * to warrant running the analyzer (and spending tokens).
  */
 
-import type { Observation } from "./types.js";
+import type { Observation, PromptFrequencyTable } from "./types.js";
+import { normalizePrompt, hashPrompt } from "./prompt-frequency.js";
 
-/**
- * Score threshold below which a batch is considered low-signal.
- * Batches scoring below this are skipped with a log entry.
- */
 export const LOW_SIGNAL_THRESHOLD = 3;
+
+export interface FrequencyBoostContext {
+  readonly projectFrequency: PromptFrequencyTable;
+  readonly minSessions: number;
+  readonly scoreBoost: number;
+}
 
 interface ScoreResult {
   readonly score: number;
   readonly errors: number;
   readonly corrections: number;
   readonly userPrompts: number;
+  readonly recurringPrompts: number;
 }
 
-/**
- * Scores an observation batch for signal richness.
- *
- * Scoring rules:
- * - Error observation (is_error: true): +2 points
- * - user_prompt after an error (user correction): +3 points
- * - Other user_prompt events (potential corrections/redirections): +1 point
- *
- * @param lines - Raw JSONL observation lines (preprocessed or raw)
- * @returns Score result with breakdown
- */
-export function scoreObservationBatch(lines: string[]): ScoreResult {
+export function scoreObservationBatch(
+  lines: string[],
+  freqContext?: FrequencyBoostContext
+): ScoreResult {
   let score = 0;
   let errors = 0;
   let corrections = 0;
   let userPrompts = 0;
+  let recurringPrompts = 0;
   let lastWasError = false;
 
   for (const line of lines) {
@@ -45,7 +42,7 @@ export function scoreObservationBatch(lines: string[]): ScoreResult {
     try {
       obs = JSON.parse(trimmed) as Partial<Observation>;
     } catch {
-      continue; // Skip malformed lines
+      continue;
     }
 
     if (obs.is_error) {
@@ -63,18 +60,31 @@ export function scoreObservationBatch(lines: string[]): ScoreResult {
       } else {
         score += 1;
       }
+
+      // Recurring prompt boost (second pass inline)
+      if (freqContext && obs.input) {
+        const normalized = normalizePrompt(obs.input);
+        if (normalized) {
+          const key = hashPrompt(normalized);
+          const entry = freqContext.projectFrequency[key];
+          if (entry && entry.sessions.length >= freqContext.minSessions) {
+            score += freqContext.scoreBoost;
+            recurringPrompts++;
+          }
+        }
+      }
     }
 
     lastWasError = false;
   }
 
-  return { score, errors, corrections, userPrompts };
+  return { score, errors, corrections, userPrompts, recurringPrompts };
 }
 
-/**
- * Returns true if the batch is low-signal and analysis should be skipped.
- */
-export function isLowSignalBatch(lines: string[]): boolean {
-  const { score } = scoreObservationBatch(lines);
+export function isLowSignalBatch(
+  lines: string[],
+  freqContext?: FrequencyBoostContext
+): boolean {
+  const { score } = scoreObservationBatch(lines, freqContext);
   return score < LOW_SIGNAL_THRESHOLD;
 }

--- a/src/prompt-frequency.test.ts
+++ b/src/prompt-frequency.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  normalizePrompt,
+  hashPrompt,
+  updateFrequencyTable,
+  updateGlobalFrequencyTable,
+  updateFrequencyTablesFromLines,
+  loadProjectFrequencyTable,
+  saveProjectFrequencyTable,
+  loadGlobalFrequencyTable,
+  saveGlobalFrequencyTable,
+} from "./prompt-frequency.js";
+import type {
+  PromptFrequencyTable,
+  GlobalPromptFrequencyTable,
+  Observation,
+} from "./types.js";
+
+const NOW = new Date("2026-03-27T12:00:00Z");
+
+const base: Omit<Observation, "event"> = {
+  timestamp: "2026-03-27T12:00:00Z",
+  session: "sess-1",
+  project_id: "proj-1",
+  project_name: "test",
+};
+
+function line(obs: Partial<Observation>): string {
+  return JSON.stringify({ ...base, ...obs });
+}
+
+function makeTmpBase(): string {
+  return mkdtempSync(join(tmpdir(), "pf-test-"));
+}
+
+// ---------------------------------------------------------------------------
+// normalizePrompt
+// ---------------------------------------------------------------------------
+
+describe("normalizePrompt", () => {
+  it("lowercases and trims", () => {
+    expect(normalizePrompt("  PR It  ")).toBe("pr it");
+  });
+
+  it("collapses interior whitespace", () => {
+    expect(normalizePrompt("ship   it   now")).toBe("ship it now");
+  });
+
+  it("strips trailing punctuation", () => {
+    expect(normalizePrompt("deploy!")).toBe("deploy");
+    expect(normalizePrompt("do it...")).toBe("do it");
+    expect(normalizePrompt("go?!")).toBe("go");
+    expect(normalizePrompt("test;")).toBe("test");
+    expect(normalizePrompt("run:")).toBe("run");
+    expect(normalizePrompt("ok,")).toBe("ok");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(normalizePrompt("")).toBe("");
+    expect(normalizePrompt("   ")).toBe("");
+  });
+
+  it("returns empty for punctuation-only input", () => {
+    expect(normalizePrompt("...")).toBe("");
+    expect(normalizePrompt("!?")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashPrompt
+// ---------------------------------------------------------------------------
+
+describe("hashPrompt", () => {
+  it("returns deterministic hex string", () => {
+    const h1 = hashPrompt("pr it");
+    const h2 = hashPrompt("pr it");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces different hashes for different inputs", () => {
+    expect(hashPrompt("pr it")).not.toBe(hashPrompt("ship it"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateFrequencyTable
+// ---------------------------------------------------------------------------
+
+describe("updateFrequencyTable", () => {
+  it("creates entry on first occurrence", () => {
+    const result = updateFrequencyTable({}, "PR it", "sess-1", NOW);
+    const key = hashPrompt(normalizePrompt("PR it"));
+    expect(result[key]).toEqual({
+      count: 1,
+      sessions: ["sess-1"],
+      last_text: "PR it",
+      first_seen: NOW.toISOString(),
+      last_seen: NOW.toISOString(),
+    });
+  });
+
+  it("deduplicates same session", () => {
+    let table: PromptFrequencyTable = {};
+    table = updateFrequencyTable(table, "PR it", "sess-1", NOW);
+    table = updateFrequencyTable(table, "PR it", "sess-1", NOW);
+    const key = hashPrompt(normalizePrompt("PR it"));
+    expect(table[key]!.count).toBe(2);
+    expect(table[key]!.sessions).toEqual(["sess-1"]);
+  });
+
+  it("tracks distinct sessions", () => {
+    let table: PromptFrequencyTable = {};
+    table = updateFrequencyTable(table, "PR it", "sess-1", NOW);
+    table = updateFrequencyTable(table, "PR it", "sess-2", NOW);
+    const key = hashPrompt(normalizePrompt("PR it"));
+    expect(table[key]!.count).toBe(2);
+    expect(table[key]!.sessions).toEqual(["sess-1", "sess-2"]);
+  });
+
+  it("returns table unchanged for empty text", () => {
+    const original: PromptFrequencyTable = {};
+    const result = updateFrequencyTable(original, "  ", "sess-1", NOW);
+    expect(result).toBe(original);
+  });
+
+  it("does not mutate input table", () => {
+    const original: PromptFrequencyTable = {};
+    updateFrequencyTable(original, "PR it", "sess-1", NOW);
+    expect(Object.keys(original)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateGlobalFrequencyTable
+// ---------------------------------------------------------------------------
+
+describe("updateGlobalFrequencyTable", () => {
+  it("tracks project_ids", () => {
+    let table: GlobalPromptFrequencyTable = {};
+    table = updateGlobalFrequencyTable(table, "PR it", "sess-1", "proj-1", NOW);
+    table = updateGlobalFrequencyTable(table, "PR it", "sess-2", "proj-2", NOW);
+    const key = hashPrompt(normalizePrompt("PR it"));
+    expect(table[key]!.project_ids).toEqual(["proj-1", "proj-2"]);
+  });
+
+  it("deduplicates project_ids", () => {
+    let table: GlobalPromptFrequencyTable = {};
+    table = updateGlobalFrequencyTable(table, "PR it", "sess-1", "proj-1", NOW);
+    table = updateGlobalFrequencyTable(table, "PR it", "sess-2", "proj-1", NOW);
+    const key = hashPrompt(normalizePrompt("PR it"));
+    expect(table[key]!.project_ids).toEqual(["proj-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateFrequencyTablesFromLines
+// ---------------------------------------------------------------------------
+
+describe("updateFrequencyTablesFromLines", () => {
+  it("processes user_prompt events with input", () => {
+    const lines = [
+      line({ event: "user_prompt", input: "PR it" }),
+      line({ event: "user_prompt", input: "ship it" }),
+    ];
+    const { project, global } = updateFrequencyTablesFromLines(lines, {}, {}, NOW);
+    expect(Object.keys(project)).toHaveLength(2);
+    expect(Object.keys(global)).toHaveLength(2);
+  });
+
+  it("skips non-user_prompt events", () => {
+    const lines = [
+      line({ event: "tool_complete", tool: "bash" }),
+      line({ event: "turn_end" }),
+    ];
+    const { project } = updateFrequencyTablesFromLines(lines, {}, {}, NOW);
+    expect(Object.keys(project)).toHaveLength(0);
+  });
+
+  it("skips user_prompt with no input", () => {
+    const lines = [line({ event: "user_prompt" })];
+    const { project } = updateFrequencyTablesFromLines(lines, {}, {}, NOW);
+    expect(Object.keys(project)).toHaveLength(0);
+  });
+
+  it("skips malformed JSON", () => {
+    const lines = ["not json", line({ event: "user_prompt", input: "ok" })];
+    const { project } = updateFrequencyTablesFromLines(lines, {}, {}, NOW);
+    expect(Object.keys(project)).toHaveLength(1);
+  });
+
+  it("skips blank lines", () => {
+    const lines = ["", "  ", line({ event: "user_prompt", input: "ok" })];
+    const { project } = updateFrequencyTablesFromLines(lines, {}, {}, NOW);
+    expect(Object.keys(project)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Load / save round-trips
+// ---------------------------------------------------------------------------
+
+describe("project frequency table I/O", () => {
+  it("returns empty table when file is absent", () => {
+    const base = makeTmpBase();
+    expect(loadProjectFrequencyTable("proj-1", base)).toEqual({});
+  });
+
+  it("round-trips save and load", () => {
+    const base = makeTmpBase();
+    const table: PromptFrequencyTable = {
+      abc: {
+        count: 3,
+        sessions: ["s1", "s2"],
+        last_text: "PR it",
+        first_seen: "2026-01-01T00:00:00Z",
+        last_seen: "2026-03-27T00:00:00Z",
+      },
+    };
+    saveProjectFrequencyTable(table, "proj-1", base);
+    expect(loadProjectFrequencyTable("proj-1", base)).toEqual(table);
+  });
+});
+
+describe("global frequency table I/O", () => {
+  it("returns empty table when file is absent", () => {
+    const base = makeTmpBase();
+    expect(loadGlobalFrequencyTable(base)).toEqual({});
+  });
+
+  it("round-trips save and load", () => {
+    const base = makeTmpBase();
+    const table: GlobalPromptFrequencyTable = {
+      abc: {
+        count: 5,
+        sessions: ["s1", "s2", "s3"],
+        project_ids: ["p1", "p2"],
+        last_text: "ship it",
+        first_seen: "2026-01-01T00:00:00Z",
+        last_seen: "2026-03-27T00:00:00Z",
+      },
+    };
+    saveGlobalFrequencyTable(table, base);
+    expect(loadGlobalFrequencyTable(base)).toEqual(table);
+  });
+});

--- a/src/prompt-frequency.ts
+++ b/src/prompt-frequency.ts
@@ -1,0 +1,196 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type {
+  Observation,
+  PromptFrequencyEntry,
+  PromptFrequencyTable,
+  GlobalPromptFrequencyEntry,
+  GlobalPromptFrequencyTable,
+} from "./types.js";
+import { getBaseDir, getProjectDir } from "./storage.js";
+
+// ---------------------------------------------------------------------------
+// Normalization & hashing
+// ---------------------------------------------------------------------------
+
+const TRAILING_PUNCT = /[.,!?;:]+$/;
+
+export function normalizePrompt(text: string): string {
+  return text.toLowerCase().trim().replace(/\s+/g, " ").replace(TRAILING_PUNCT, "");
+}
+
+export function hashPrompt(normalized: string): string {
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Storage paths
+// ---------------------------------------------------------------------------
+
+export function getProjectFrequencyPath(
+  projectId: string,
+  baseDir = getBaseDir()
+): string {
+  return join(getProjectDir(projectId, baseDir), "prompt-frequency.json");
+}
+
+export function getGlobalFrequencyPath(baseDir = getBaseDir()): string {
+  return join(baseDir, "prompt-frequency.json");
+}
+
+// ---------------------------------------------------------------------------
+// Load / save
+// ---------------------------------------------------------------------------
+
+export function loadProjectFrequencyTable(
+  projectId: string,
+  baseDir = getBaseDir()
+): PromptFrequencyTable {
+  const p = getProjectFrequencyPath(projectId, baseDir);
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as PromptFrequencyTable;
+  } catch {
+    return {};
+  }
+}
+
+export function saveProjectFrequencyTable(
+  table: PromptFrequencyTable,
+  projectId: string,
+  baseDir = getBaseDir()
+): void {
+  const p = getProjectFrequencyPath(projectId, baseDir);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(table, null, 2), "utf-8");
+}
+
+export function loadGlobalFrequencyTable(
+  baseDir = getBaseDir()
+): GlobalPromptFrequencyTable {
+  const p = getGlobalFrequencyPath(baseDir);
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as GlobalPromptFrequencyTable;
+  } catch {
+    return {};
+  }
+}
+
+export function saveGlobalFrequencyTable(
+  table: GlobalPromptFrequencyTable,
+  baseDir = getBaseDir()
+): void {
+  const p = getGlobalFrequencyPath(baseDir);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(table, null, 2), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Pure update functions (immutable)
+// ---------------------------------------------------------------------------
+
+export function updateFrequencyTable(
+  table: PromptFrequencyTable,
+  text: string,
+  sessionId: string,
+  now = new Date()
+): PromptFrequencyTable {
+  const normalized = normalizePrompt(text);
+  if (!normalized) return table;
+
+  const key = hashPrompt(normalized);
+  const existing = table[key];
+  const nowIso = now.toISOString();
+
+  const entry: PromptFrequencyEntry = existing
+    ? {
+        count: existing.count + 1,
+        sessions: Array.from(new Set([...existing.sessions, sessionId])),
+        last_text: text,
+        first_seen: existing.first_seen,
+        last_seen: nowIso,
+      }
+    : {
+        count: 1,
+        sessions: [sessionId],
+        last_text: text,
+        first_seen: nowIso,
+        last_seen: nowIso,
+      };
+
+  return { ...table, [key]: entry };
+}
+
+export function updateGlobalFrequencyTable(
+  table: GlobalPromptFrequencyTable,
+  text: string,
+  sessionId: string,
+  projectId: string,
+  now = new Date()
+): GlobalPromptFrequencyTable {
+  const normalized = normalizePrompt(text);
+  if (!normalized) return table;
+
+  const key = hashPrompt(normalized);
+  const existing = table[key];
+  const nowIso = now.toISOString();
+
+  const entry: GlobalPromptFrequencyEntry = existing
+    ? {
+        count: existing.count + 1,
+        sessions: Array.from(new Set([...existing.sessions, sessionId])),
+        project_ids: Array.from(new Set([...existing.project_ids, projectId])),
+        last_text: text,
+        first_seen: existing.first_seen,
+        last_seen: nowIso,
+      }
+    : {
+        count: 1,
+        sessions: [sessionId],
+        project_ids: [projectId],
+        last_text: text,
+        first_seen: nowIso,
+        last_seen: nowIso,
+      };
+
+  return { ...table, [key]: entry };
+}
+
+// ---------------------------------------------------------------------------
+// Batch update from observation lines
+// ---------------------------------------------------------------------------
+
+export function updateFrequencyTablesFromLines(
+  lines: readonly string[],
+  projectTable: PromptFrequencyTable,
+  globalTable: GlobalPromptFrequencyTable,
+  now = new Date()
+): { readonly project: PromptFrequencyTable; readonly global: GlobalPromptFrequencyTable } {
+  let project = projectTable;
+  let global = globalTable;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let obs: Partial<Observation>;
+    try {
+      obs = JSON.parse(trimmed) as Partial<Observation>;
+    } catch {
+      continue;
+    }
+
+    if (obs.event !== "user_prompt" || !obs.input) continue;
+
+    const sessionId = obs.session ?? "unknown";
+    const projectId = obs.project_id ?? "unknown";
+
+    project = updateFrequencyTable(project, obs.input, sessionId, now);
+    global = updateGlobalFrequencyTable(global, obs.input, sessionId, projectId, now);
+  }
+
+  return { project, global };
+}

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -164,6 +164,8 @@ describe("types exports", () => {
       dreaming_enabled: true,
       consolidation_interval_days: 7,
       consolidation_min_sessions: 10,
+      recurring_prompt_min_sessions: 3,
+      recurring_prompt_score_boost: 3,
     };
     expect(config.run_interval_minutes).toBe(5);
     expect(config.model).toBe("claude-haiku-4-5");

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,4 +118,26 @@ export interface Config {
   dreaming_enabled: boolean; // whether automatic consolidation runs during normal analysis
   consolidation_interval_days: number; // minimum days between consolidation runs
   consolidation_min_sessions: number; // minimum sessions since last consolidation
+  // Recurring prompt detection
+  recurring_prompt_min_sessions: number; // distinct sessions before a prompt is considered recurring
+  recurring_prompt_score_boost: number; // score added to batch when a recurring prompt is present
 }
+
+// ---------------------------------------------------------------------------
+// Prompt Frequency
+// ---------------------------------------------------------------------------
+
+export interface PromptFrequencyEntry {
+  readonly count: number;
+  readonly sessions: readonly string[];
+  readonly last_text: string;
+  readonly first_seen: string; // ISO 8601
+  readonly last_seen: string; // ISO 8601
+}
+
+export interface GlobalPromptFrequencyEntry extends PromptFrequencyEntry {
+  readonly project_ids: readonly string[];
+}
+
+export type PromptFrequencyTable = Record<string, PromptFrequencyEntry>;
+export type GlobalPromptFrequencyTable = Record<string, GlobalPromptFrequencyEntry>;


### PR DESCRIPTION
## Summary

Closes #40

- Adds per-project and global `prompt-frequency.json` tables that track how often short user prompts recur across sessions
- When a prompt has been seen in >= N distinct sessions (default 3), the signal scorer applies a configurable score boost (+3) so low-signal batches containing recurring prompts survive the threshold and reach the analyzer
- Frequency tables are persisted **before** the signal check so counts accumulate even for skipped batches
- Global table tracks `project_ids` for future cross-project instinct features; boost currently uses project-level data only
- Prompts are normalized (lowercase, trim, collapse whitespace, strip trailing punctuation) and SHA-256 hashed as storage keys

### New config keys

| Key | Default | Purpose |
|-----|---------|---------|
| `recurring_prompt_min_sessions` | `3` | Distinct sessions before boosting |
| `recurring_prompt_score_boost` | `3` | Score points added per recurring prompt |

### Files

- **New:** `src/prompt-frequency.ts` — normalization, hashing, frequency table CRUD
- **New:** `src/prompt-frequency.test.ts` — 23 tests
- **Modified:** `src/types.ts`, `src/config.ts`, `src/observation-signal.ts`, `src/cli/analyze.ts`
- **Test updates:** `src/observation-signal.test.ts`, `src/config.test.ts`, `src/types.test.ts`, `src/instinct-injector.test.ts`, `src/instinct-loader.test.ts`

## Test plan

- [x] 772/772 tests pass (`npx vitest run`)
- [x] Zero type errors (`npx tsc --noEmit`)
- [x] ESLint clean
- [ ] Manual: create a `prompt-frequency.json` with a prompt seen in 3+ sessions, run analyzer against a batch with only that prompt, confirm analysis proceeds