### PR TITLE
feat: model switch pattern detection (#42)

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -503,6 +503,7 @@ A warning is logged when budget enforcement triggers.
 | Error observation (`is_error: true`) | +2 |
 | `user_prompt` immediately after an error (correction) | +3 |
 | Any other `user_prompt` | +1 |
+| Model change (`model_select`) | +1 |
 
 If the total score is below `LOW_SIGNAL_THRESHOLD` (3), analysis is skipped entirely with a log entry of `"low-signal batch"`. This avoids burning tokens on batches containing only routine successful tool calls.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "pi-continuous-learning",
       "version": "0.9.0",
+      "license": "MIT",
+      "bin": {
+        "pi-cl-analyze": "dist/cli/analyze.js"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -14,6 +18,9 @@
         "eslint": "^9.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "@mariozechner/pi-ai": "^0.62.0",
@@ -1647,9 +1654,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1666,9 +1670,6 @@
       "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1687,9 +1688,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1705,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1721,6 @@
       "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2063,9 +2055,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2080,9 +2069,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2097,9 +2083,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2114,9 +2097,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2131,9 +2111,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2148,9 +2125,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,9 +2139,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,9 +2153,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2199,9 +2167,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2216,9 +2181,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,9 +2195,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2250,9 +2209,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2267,9 +2223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/observation-signal.test.ts
+++ b/src/observation-signal.test.ts
@@ -66,6 +66,12 @@ describe("scoreObservationBatch", () => {
     expect(result.corrections).toBe(0);
   });
 
+  it("scores model_select at +1", () => {
+    const lines = [line({ event: "model_select" })];
+    const result = scoreObservationBatch(lines);
+    expect(result.score).toBe(1);
+  });
+
   it("resets error flag after non-error event", () => {
     const lines = [
       line({ event: "tool_complete", tool: "bash", is_error: true }),

--- a/src/observation-signal.ts
+++ b/src/observation-signal.ts
@@ -73,6 +73,8 @@ export function scoreObservationBatch(
           }
         }
       }
+    } else if (obs.event === "model_select") {
+      score += 1;
     }
 
     lastWasError = false;

--- a/src/prompts/analyzer-system-single-shot.ts
+++ b/src/prompts/analyzer-system-single-shot.ts
@@ -81,6 +81,7 @@ Analyze observations for these categories:
 
 ### Model Preferences
 - model_select events track when users switch models
+- Trigger: the context or task type right before the switch; Action: the preferred model to use. Example: "When doing X type of work, user prefers model Y."
 
 ## Feedback Analysis
 


### PR DESCRIPTION
## Summary

- Adds `+1` signal score for `model_select` events in `scoreObservationBatch`, preventing model-switch-only batches from being silently dropped by the low-signal early exit
- Updates the analyzer system prompt with a concrete heuristic: trigger = context/task type before the switch; action = preferred model (e.g. "When doing X type of work, user prefers model Y.")
- Adds a test case for `model_select` scoring and updates `docs/internals.md` signal table

Closes #42.

## Test plan

- [x] `npm run test` — all 773 tests pass
- [x] `npx eslint src/` — no lint errors
- [x] `npx tsc --noEmit` — no type errors