### PR TITLE
feat: active instinct confirmation signal from clean sessions (#41)

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -504,6 +504,7 @@ A warning is logged when budget enforcement triggers.
 | `user_prompt` immediately after an error (correction) | +3 |
 | Any other `user_prompt` | +1 |
 | Model change (`model_select`) | +1 |
+| Active instinct confirmation (clean session, no errors/corrections) | +1 per distinct instinct ID, capped at +3 |
 
 If the total score is below `LOW_SIGNAL_THRESHOLD` (3), analysis is skipped entirely with a log entry of `"low-signal batch"`. This avoids burning tokens on batches containing only routine successful tool calls.
 

--- a/src/observation-signal.test.ts
+++ b/src/observation-signal.test.ts
@@ -3,6 +3,7 @@ import {
   scoreObservationBatch,
   isLowSignalBatch,
   LOW_SIGNAL_THRESHOLD,
+  ACTIVE_INSTINCT_BOOST_CAP,
   type FrequencyBoostContext,
 } from "./observation-signal.js";
 import type { Observation, PromptFrequencyTable } from "./types.js";
@@ -204,5 +205,92 @@ describe("isLowSignalBatch with frequency boost", () => {
     // Without boost: score=1, below threshold. With boost: score=4.
     expect(isLowSignalBatch(lines)).toBe(true);
     expect(isLowSignalBatch(lines, ctx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active instinct confirmation boost
+// ---------------------------------------------------------------------------
+
+describe("scoreObservationBatch active instinct boost", () => {
+  it("adds +1 per distinct active instinct on a clean session", () => {
+    const lines = [
+      line({ event: "user_prompt", active_instincts: ["inst-a"] }),
+      line({ event: "tool_complete", tool: "read", active_instincts: ["inst-a", "inst-b"] }),
+      line({ event: "agent_end", active_instincts: ["inst-b"] }),
+    ];
+    const result = scoreObservationBatch(lines);
+    // user_prompt: +1, active instinct boost: +2 (inst-a, inst-b)
+    expect(result.score).toBe(3);
+    expect(result.activeInstinctBoost).toBe(2);
+  });
+
+  it("caps boost at ACTIVE_INSTINCT_BOOST_CAP when more than cap distinct IDs present", () => {
+    const lines = [
+      line({ event: "user_prompt", active_instincts: ["a", "b", "c", "d"] }),
+    ];
+    const result = scoreObservationBatch(lines);
+    expect(result.activeInstinctBoost).toBe(ACTIVE_INSTINCT_BOOST_CAP);
+    expect(result.score).toBe(1 + ACTIVE_INSTINCT_BOOST_CAP);
+  });
+
+  it("does not boost when errors are present", () => {
+    const lines = [
+      line({ event: "tool_complete", tool: "bash", is_error: true, active_instincts: ["inst-a"] }),
+      line({ event: "user_prompt" }),
+    ];
+    const result = scoreObservationBatch(lines);
+    expect(result.activeInstinctBoost).toBe(0);
+  });
+
+  it("does not boost when corrections are present", () => {
+    const lines = [
+      line({ event: "tool_complete", tool: "bash", is_error: true, active_instincts: ["inst-a"] }),
+      line({ event: "user_prompt", active_instincts: ["inst-a"] }), // correction
+    ];
+    const result = scoreObservationBatch(lines);
+    expect(result.corrections).toBe(1);
+    expect(result.activeInstinctBoost).toBe(0);
+  });
+
+  it("does not boost when no active instincts in the batch", () => {
+    const lines = [
+      line({ event: "user_prompt" }),
+      line({ event: "tool_complete", tool: "read" }),
+    ];
+    const result = scoreObservationBatch(lines);
+    expect(result.activeInstinctBoost).toBe(0);
+  });
+
+  it("deduplicates the same instinct ID across multiple observations", () => {
+    const lines = [
+      line({ event: "user_prompt", active_instincts: ["inst-a"] }),
+      line({ event: "tool_complete", tool: "read", active_instincts: ["inst-a"] }),
+      line({ event: "agent_end", active_instincts: ["inst-a"] }),
+    ];
+    const result = scoreObservationBatch(lines);
+    expect(result.activeInstinctBoost).toBe(1);
+  });
+
+  it("returns activeInstinctBoost=0 when no active instincts and no errors", () => {
+    const result = scoreObservationBatch([]);
+    expect(result.activeInstinctBoost).toBe(0);
+  });
+});
+
+describe("isLowSignalBatch active instinct boost", () => {
+  it("returns false when active instinct boost pushes score past threshold", () => {
+    // user_prompt (+1) + 2 distinct instincts (+2) = 3, meets threshold
+    const lines = [
+      line({ event: "user_prompt", active_instincts: ["inst-a", "inst-b"] }),
+    ];
+    expect(isLowSignalBatch(lines)).toBe(false);
+  });
+
+  it("returns true for single instinct with single user_prompt (score=2 < 3)", () => {
+    const lines = [
+      line({ event: "user_prompt", active_instincts: ["inst-a"] }),
+    ];
+    expect(isLowSignalBatch(lines)).toBe(true);
   });
 });

--- a/src/observation-signal.ts
+++ b/src/observation-signal.ts
@@ -21,7 +21,10 @@ interface ScoreResult {
   readonly corrections: number;
   readonly userPrompts: number;
   readonly recurringPrompts: number;
+  readonly activeInstinctBoost: number;
 }
+
+export const ACTIVE_INSTINCT_BOOST_CAP = 3;
 
 export function scoreObservationBatch(
   lines: string[],
@@ -33,6 +36,7 @@ export function scoreObservationBatch(
   let userPrompts = 0;
   let recurringPrompts = 0;
   let lastWasError = false;
+  const seenActiveInstincts = new Set<string>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -43,6 +47,12 @@ export function scoreObservationBatch(
       obs = JSON.parse(trimmed) as Partial<Observation>;
     } catch {
       continue;
+    }
+
+    if (Array.isArray(obs.active_instincts)) {
+      for (const id of obs.active_instincts) {
+        if (id) seenActiveInstincts.add(id);
+      }
     }
 
     if (obs.is_error) {
@@ -80,7 +90,14 @@ export function scoreObservationBatch(
     lastWasError = false;
   }
 
-  return { score, errors, corrections, userPrompts, recurringPrompts };
+  // Implicit confirmation boost: clean session with active instincts
+  let activeInstinctBoost = 0;
+  if (errors === 0 && corrections === 0 && seenActiveInstincts.size > 0) {
+    activeInstinctBoost = Math.min(seenActiveInstincts.size, ACTIVE_INSTINCT_BOOST_CAP);
+    score += activeInstinctBoost;
+  }
+
+  return { score, errors, corrections, userPrompts, recurringPrompts, activeInstinctBoost };
 }
 
 export function isLowSignalBatch(

--- a/src/prompts/analyzer-system-single-shot.ts
+++ b/src/prompts/analyzer-system-single-shot.ts
@@ -93,6 +93,16 @@ Use this to update existing instinct confidence scores:
 - Contradicted (-0.15): instinct was active but user corrected the agent
 - Inactive (no change): instinct was injected but trigger never arose
 
+### Implicit confirmation from clean sessions
+
+When a batch contains zero errors and zero user corrections, and one or more
+instinct IDs appear in active_instincts across the observations, treat this as
+implicit confirmation for those instincts — the agent executed cleanly while
+the instincts were injected. Apply the same confirmed_count increment rules
+(per-session deduplication, baseline behavior filtering, diminishing returns)
+as for explicit confirmations. Do not count it if the instinct's trigger was
+never relevant to the work done in the session.
+
 When updating, increment the corresponding count field.
 
 ### Confirmation confidence deltas (diminishing returns)


### PR DESCRIPTION
## Summary

- Adds `+1` per distinct active instinct ID (capped at `+3`) to the signal score when a batch has zero errors and zero corrections — preventing clean confirmation sessions from being silently dropped by the low-signal early exit
- Exports `ACTIVE_INSTINCT_BOOST_CAP = 3` constant alongside `LOW_SIGNAL_THRESHOLD`
- Updates the analyzer system prompt with an **Implicit confirmation from clean sessions** rule, applying the same per-session deduplication, baseline behavior filtering, and diminishing returns as explicit confirmations
- Updates `docs/internals.md` signal scoring table

Closes #41.

## Test plan

- [x] 9 new test cases covering: boost applied, cap enforced, no boost on errors, no boost on corrections, no boost with no active instincts, deduplication, `isLowSignalBatch` integration
- [x] `npm run test` — all 782 tests pass
- [x] `npx eslint src/` — no lint errors
- [x] `npx tsc --noEmit` — no type errors