### PR TITLE
feat: normalize relative dates in evidence strings

### DIFF
--- a/src/cli/analyze-single-shot.ts
+++ b/src/cli/analyze-single-shot.ts
@@ -17,6 +17,7 @@ import {
   findSimilarInstinct,
 } from "../instinct-validator.js";
 import { confirmationDelta } from "../confidence.js";
+import { normalizeRelativeDates } from "../text-utils.js";
 
 export interface InstinctChangePayload {
   id: string;
@@ -188,7 +189,9 @@ export function buildInstinctFromChange(
     confirmed_count: resolvedConfirmedCount,
     contradicted_count: payload.contradicted_count ?? 0,
     inactive_count: payload.inactive_count ?? 0,
-    ...(payload.evidence !== undefined ? { evidence: payload.evidence } : {}),
+    ...(payload.evidence !== undefined
+      ? { evidence: payload.evidence.map((e) => normalizeRelativeDates(e)) }
+      : {}),
     ...(resolvedLastConfirmedSession !== undefined
       ? { last_confirmed_session: resolvedLastConfirmedSession }
       : {}),

--- a/src/instinct-tools.ts
+++ b/src/instinct-tools.ts
@@ -12,6 +12,7 @@ import {
 } from "./instinct-store.js";
 import { getProjectInstinctsDir, getGlobalInstinctsDir } from "./storage.js";
 import { validateInstinct, findSimilarInstinct } from "./instinct-validator.js";
+import { normalizeRelativeDates } from "./text-utils.js";
 
 function getInstinctsDir(
   scope: "project" | "global",
@@ -196,7 +197,9 @@ export function createInstinctWriteTool(
         confirmed_count: params.confirmed_count ?? 0,
         contradicted_count: params.contradicted_count ?? 0,
         inactive_count: params.inactive_count ?? 0,
-        ...(params.evidence ? { evidence: params.evidence } : {}),
+        ...(params.evidence
+          ? { evidence: params.evidence.map((e) => normalizeRelativeDates(e)) }
+          : {}),
       };
 
       saveInstinct(instinct, dir);
@@ -406,7 +409,9 @@ export function createInstinctMergeTool(
         confirmed_count: 0,
         contradicted_count: 0,
         inactive_count: 0,
-        ...(merged.evidence ? { evidence: merged.evidence } : {}),
+        ...(merged.evidence
+          ? { evidence: merged.evidence.map((e) => normalizeRelativeDates(e)) }
+          : {}),
       };
 
       saveInstinct(instinct, dir);

--- a/src/text-utils.test.ts
+++ b/src/text-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { normalizeRelativeDates } from "./text-utils.js";
+
+const NOW = new Date("2026-04-06T12:00:00Z");
+
+describe("normalizeRelativeDates", () => {
+  it("replaces 'today'", () => {
+    expect(normalizeRelativeDates("Today we fixed it", NOW)).toBe(
+      "2026-04-06 we fixed it",
+    );
+  });
+
+  it("replaces 'this morning'", () => {
+    expect(normalizeRelativeDates("This morning the build broke", NOW)).toBe(
+      "2026-04-06 the build broke",
+    );
+  });
+
+  it("replaces 'yesterday'", () => {
+    expect(normalizeRelativeDates("Yesterday's refactor showed X", NOW)).toBe(
+      "2026-04-05's refactor showed X",
+    );
+  });
+
+  it("replaces 'last week'", () => {
+    expect(normalizeRelativeDates("Last week we discovered this", NOW)).toBe(
+      "week of 2026-03-30 we discovered this",
+    );
+  });
+
+  it("replaces 'N days ago' (singular)", () => {
+    expect(normalizeRelativeDates("1 day ago the test failed", NOW)).toBe(
+      "2026-04-05 the test failed",
+    );
+  });
+
+  it("replaces 'N days ago' (plural)", () => {
+    expect(normalizeRelativeDates("3 days ago we merged this", NOW)).toBe(
+      "2026-04-03 we merged this",
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeRelativeDates("YESTERDAY we saw this", NOW)).toBe(
+      "2026-04-05 we saw this",
+    );
+  });
+
+  it("replaces multiple occurrences in one string", () => {
+    const result = normalizeRelativeDates(
+      "Yesterday we started, today we finished",
+      NOW,
+    );
+    expect(result).toBe("2026-04-05 we started, 2026-04-06 we finished");
+  });
+
+  it("leaves strings without relative dates unchanged", () => {
+    const text = "Session abc123: the refactor improved performance";
+    expect(normalizeRelativeDates(text, NOW)).toBe(text);
+  });
+
+  it("does not replace partial word matches", () => {
+    const text = "everyday patterns matter";
+    expect(normalizeRelativeDates(text, NOW)).toBe(text);
+  });
+});

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -1,0 +1,24 @@
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function subDays(d: Date, n: number): Date {
+  return new Date(d.getTime() - n * 86_400_000);
+}
+
+/**
+ * Replaces relative date references in evidence strings with absolute ISO dates
+ * so they remain meaningful after the session that created them.
+ *
+ * Applied only at write time — existing evidence is left untouched.
+ */
+export function normalizeRelativeDates(text: string, now = new Date()): string {
+  return text
+    .replace(/\btoday\b/gi, formatDate(now))
+    .replace(/\bthis morning\b/gi, formatDate(now))
+    .replace(/\byesterday\b/gi, formatDate(subDays(now, 1)))
+    .replace(/\blast week\b/gi, `week of ${formatDate(subDays(now, 7))}`)
+    .replace(/\b(\d+) days? ago\b/gi, (_, n: string) =>
+      formatDate(subDays(now, parseInt(n, 10))),
+    );
+}


### PR DESCRIPTION
Closes #35.

## Summary

- Adds `src/text-utils.ts` with a `normalizeRelativeDates` function that replaces relative date references ("yesterday", "last week", "3 days ago", etc.) with absolute ISO dates
- Applied at write time in `buildInstinctFromChange` (`analyze-single-shot.ts`) and in both the write and merge tool paths (`instinct-tools.ts`)
- 10 new tests covering all patterns, case-insensitivity, multiple replacements, and word-boundary safety

## Test plan

- [x] `npm run check` passes (792 tests, clean lint + typecheck)