### PR TITLE
feat: generate INSTINCT_SUMMARY.md after analyzer runs and tool operations

### DIFF
--- a/packages/pi-continuous-learning/src/cli/analyze.ts
+++ b/packages/pi-continuous-learning/src/cli/analyze.ts
@@ -61,6 +61,10 @@ import {
   loadGlobalInstincts,
   saveInstinct,
 } from "../instinct-store.js";
+import {
+  generateGlobalSummary,
+  generateProjectSummary,
+} from "../instinct-summary.js";
 import { readAgentsMd } from "../agents-md.js";
 import { homedir } from "node:os";
 import {
@@ -976,6 +980,18 @@ async function main(): Promise<void> {
     };
 
     logger.runComplete(summary);
+
+    // Regenerate summary files whenever any instincts changed
+    const anyChanges =
+      summary.total_instincts_created > 0 ||
+      summary.total_instincts_updated > 0 ||
+      summary.total_instincts_deleted > 0;
+    if (anyChanges) {
+      generateGlobalSummary(baseDir);
+      for (const stats of allProjectStats) {
+        generateProjectSummary(stats.project_id, baseDir);
+      }
+    }
   } finally {
     releaseLock(baseDir);
   }

--- a/packages/pi-continuous-learning/src/instinct-summary.ts
+++ b/packages/pi-continuous-learning/src/instinct-summary.ts
@@ -1,0 +1,134 @@
+/**
+ * Generates human-readable INSTINCT_SUMMARY.md files for browsing instincts
+ * outside of Pi sessions.
+ *
+ * Global summary: ~/.pi/continuous-learning/INSTINCT_SUMMARY.md
+ * Per-project:    ~/.pi/continuous-learning/projects/<id>/INSTINCT_SUMMARY.md
+ */
+
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+import type { Instinct, ProjectEntry } from "./types.js";
+import {
+  loadProjectInstincts,
+  loadGlobalInstincts,
+} from "./instinct-store.js";
+import {
+  getBaseDir,
+  getProjectsRegistryPath,
+  getGlobalSummaryPath,
+  getProjectSummaryPath,
+} from "./storage.js";
+
+function loadProjectsRegistry(
+  baseDir: string,
+): Record<string, ProjectEntry> {
+  const path = getProjectsRegistryPath(baseDir);
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<
+      string,
+      ProjectEntry
+    >;
+  } catch {
+    return {};
+  }
+}
+
+function formatTable(instincts: Instinct[]): string {
+  const sorted = [...instincts].sort((a, b) => b.confidence - a.confidence);
+  const rows = sorted.map(
+    (i) =>
+      `| ${i.id} | ${i.title} | ${i.confidence.toFixed(2)} | ${i.domain} |`,
+  );
+  return [
+    "| ID | Title | Confidence | Domain |",
+    "|----|-------|-----------|--------|",
+    ...rows,
+  ].join("\n");
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Regenerates the global INSTINCT_SUMMARY.md covering all global instincts
+ * and every registered project's instincts.
+ */
+export function generateGlobalSummary(baseDir = getBaseDir()): void {
+  const globalInstincts = loadGlobalInstincts(baseDir);
+  const registry = loadProjectsRegistry(baseDir);
+  const projectEntries = Object.values(registry).map((project) => ({
+    project,
+    instincts: loadProjectInstincts(project.id, baseDir),
+  }));
+
+  const lines: string[] = [
+    "# Instinct Summary",
+    `*Generated: ${new Date().toISOString()}*`,
+    "",
+    `## Global (${plural(globalInstincts.length, "instinct")})`,
+    "",
+  ];
+
+  if (globalInstincts.length === 0) {
+    lines.push("*No global instincts yet.*");
+  } else {
+    lines.push(formatTable(globalInstincts));
+  }
+
+  for (const { project, instincts } of projectEntries) {
+    lines.push(
+      "",
+      `## Project: ${project.name} (${plural(instincts.length, "instinct")})`,
+      "",
+    );
+    if (instincts.length === 0) {
+      lines.push("*No project-scoped instincts yet.*");
+    } else {
+      lines.push(formatTable(instincts));
+    }
+  }
+
+  try {
+    writeFileSync(getGlobalSummaryPath(baseDir), lines.join("\n") + "\n", "utf-8");
+  } catch {
+    // Best effort - don't crash callers on I/O failure
+  }
+}
+
+/**
+ * Regenerates the per-project INSTINCT_SUMMARY.md for a single project.
+ */
+export function generateProjectSummary(
+  projectId: string,
+  baseDir = getBaseDir(),
+): void {
+  const instincts = loadProjectInstincts(projectId, baseDir);
+  const registry = loadProjectsRegistry(baseDir);
+  const projectName = registry[projectId]?.name ?? projectId;
+
+  const lines: string[] = [
+    `# Instinct Summary: ${projectName}`,
+    `*Generated: ${new Date().toISOString()}*`,
+    "",
+    `## ${plural(instincts.length, "instinct")}`,
+    "",
+  ];
+
+  if (instincts.length === 0) {
+    lines.push("*No project-scoped instincts yet.*");
+  } else {
+    lines.push(formatTable(instincts));
+  }
+
+  try {
+    writeFileSync(
+      getProjectSummaryPath(projectId, baseDir),
+      lines.join("\n") + "\n",
+      "utf-8",
+    );
+  } catch {
+    // Best effort - don't crash callers on I/O failure
+  }
+}

--- a/packages/pi-continuous-learning/src/instinct-tools.ts
+++ b/packages/pi-continuous-learning/src/instinct-tools.ts
@@ -13,6 +13,10 @@ import {
 import { getProjectInstinctsDir, getGlobalInstinctsDir } from "./storage.js";
 import { validateInstinct, findSimilarInstinct } from "./instinct-validator.js";
 import { normalizeRelativeDates } from "./text-utils.js";
+import {
+  generateGlobalSummary,
+  generateProjectSummary,
+} from "./instinct-summary.js";
 
 function getInstinctsDir(
   scope: "project" | "global",
@@ -203,6 +207,8 @@ export function createInstinctWriteTool(
       };
 
       saveInstinct(instinct, dir);
+      if (projectId) generateProjectSummary(projectId, baseDir);
+      generateGlobalSummary(baseDir);
 
       return {
         content: [
@@ -337,6 +343,8 @@ export function createInstinctDeleteTool(
           );
         }
         unlinkSync(path);
+        if (projectId) generateProjectSummary(projectId, baseDir);
+        generateGlobalSummary(baseDir);
         return {
           content: [
             {
@@ -353,6 +361,8 @@ export function createInstinctDeleteTool(
         throw new Error(`Instinct not found: ${params.id}`);
       }
       unlinkSync(found.path);
+      if (projectId) generateProjectSummary(projectId, baseDir);
+      generateGlobalSummary(baseDir);
       return {
         content: [
           {
@@ -440,6 +450,9 @@ export function createInstinctMergeTool(
         unlinkSync(path);
         deleted.push(`${id}(${scope})`);
       }
+
+      if (projectId) generateProjectSummary(projectId, baseDir);
+      generateGlobalSummary(baseDir);
 
       return {
         content: [

--- a/packages/pi-continuous-learning/src/storage.ts
+++ b/packages/pi-continuous-learning/src/storage.ts
@@ -53,6 +53,17 @@ export function getProjectsRegistryPath(baseDir = getBaseDir()): string {
   return join(baseDir, "projects.json");
 }
 
+export function getGlobalSummaryPath(baseDir = getBaseDir()): string {
+  return join(baseDir, "INSTINCT_SUMMARY.md");
+}
+
+export function getProjectSummaryPath(
+  projectId: string,
+  baseDir = getBaseDir(),
+): string {
+  return join(getProjectDir(projectId, baseDir), "INSTINCT_SUMMARY.md");
+}
+
 function ensureDir(dir: string): void {
   mkdirSync(dir, { recursive: true });
 }


### PR DESCRIPTION
## Summary

- Adds a new `src/instinct-summary.ts` module with `generateGlobalSummary` and `generateProjectSummary` functions that write human-readable markdown tables of the full instinct corpus
- Global summary at `~/.pi/continuous-learning/INSTINCT_SUMMARY.md` (all global instincts + every project grouped by name); per-project summary at `~/.pi/continuous-learning/projects/<id>/INSTINCT_SUMMARY.md`
- `cli/analyze.ts` regenerates both after any run where instincts were created, updated, or deleted
- `instinct-tools.ts` regenerates after `instinct_write`, `instinct_delete`, and `instinct_merge` tool calls (covers `/instinct-evolve`, `/instinct-graduate`, and manual LLM tool ops)

Closes #36

## Test plan

- [ ] Run `npm run typecheck` — passes
- [ ] Run `npm test` — all 792 tests pass
- [ ] Trigger an analyzer run against a project with observations; confirm `INSTINCT_SUMMARY.md` is created in both `~/.pi/continuous-learning/` and the project directory
- [ ] Use `instinct_write` / `instinct_delete` / `instinct_merge` tools inside a Pi session; confirm both summary files are updated immediately
- [ ] Confirm a run with zero changes does **not** regenerate summary files (no unnecessary writes)