### PR TITLE
fix: update repo URLs for npm provenance and add manual publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package name to publish (e.g. pi-continuous-learning)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -19,15 +25,20 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
 
-      - name: Resolve package path from release tag
+      - name: Resolve package path
         id: pkg
         env:
           TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_PKG: ${{ inputs.package }}
         run: |
-          PKG_NAME="${TAG%-v*}"
-          PKG_PATH="packages/${PKG_NAME}"
+          if [ -n "${DISPATCH_PKG}" ]; then
+            PKG_PATH="packages/${DISPATCH_PKG}"
+          else
+            PKG_NAME="${TAG%-v*}"
+            PKG_PATH="packages/${PKG_NAME}"
+          fi
           if [ ! -d "${PKG_PATH}" ]; then
-            echo "Error: package directory '${PKG_PATH}' not found for tag '${TAG}'"
+            echo "Error: package directory '${PKG_PATH}' not found"
             exit 1
           fi
           echo "path=${PKG_PATH}" >> "$GITHUB_OUTPUT"
@@ -45,4 +56,4 @@ jobs:
 
       - name: Publish
         working-directory: ${{ steps.pkg.outputs.path }}
-        run: npm publish
+        run: npm publish --provenance --access public

--- a/packages/pi-continuous-learning/package.json
+++ b/packages/pi-continuous-learning/package.json
@@ -7,12 +7,12 @@
   "author": "Matt Devy",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MattDevy/pi-continuous-learning.git",
+    "url": "https://github.com/MattDevy/pi-extensions.git",
     "directory": "packages/pi-continuous-learning"
   },
-  "homepage": "https://github.com/MattDevy/pi-continuous-learning#readme",
+  "homepage": "https://github.com/MattDevy/pi-extensions/tree/main/packages/pi-continuous-learning#readme",
   "bugs": {
-    "url": "https://github.com/MattDevy/pi-continuous-learning/issues"
+    "url": "https://github.com/MattDevy/pi-extensions/issues"
   },
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Fixes npm publish failure caused by `repository.url` in `package.json` pointing to the old `pi-continuous-learning` repo instead of `pi-extensions` — this was rejected by npm's provenance validation
- Adds `workflow_dispatch` to `publish.yml` so any package can be manually re-published by name without needing a release event
- Adds explicit `--provenance --access public` flags to `npm publish`

## Test plan
- [ ] Merge and verify the next release publish succeeds
- [ ] Test manual dispatch via Actions → "Publish to npm" → "Run workflow" with `pi-continuous-learning`