### PR TITLE
fix(ci): prevent prepublishOnly from wiping dist during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,14 @@ jobs:
         working-directory: ${{ steps.pkg.outputs.path }}
         run: npm run check
 
+      - name: Verify dist exists
+        working-directory: ${{ steps.pkg.outputs.path }}
+        run: |
+          if [ ! -d dist ]; then
+            echo "Error: dist/ directory missing after build step"
+            exit 1
+          fi
+
       - name: Publish
         working-directory: ${{ steps.pkg.outputs.path }}
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --ignore-scripts


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` to `npm publish` in CI so `prepublishOnly` doesn't re-run `rm -rf dist`, wiping the output from the explicit Build step
- Add a "Verify dist exists" safety gate between build and publish

## Root cause

`npm publish` triggers `prepublishOnly` (`npm run build && npm run check`), which starts with `rm -rf dist`. The tsc recompilation during that lifecycle hook silently fails to produce output, so the tarball ships with only `src/` and no `dist/`. CI logs confirmed: `npm warn No bin file found at dist/cli/analyze.js`.

The workflow already runs build and check as dedicated steps, making `prepublishOnly` redundant in CI.

## Test plan

- [ ] Trigger a publish via `workflow_dispatch` and verify the tarball includes `dist/`
- [ ] Verify `npm pack --dry-run` locally after `npm run build` still includes `dist/`
- [ ] Verify local `npm publish` (dry-run) still triggers `prepublishOnly` without `--ignore-scripts`
