### PR TITLE
fix: add prepack guard to fail fast when dist is missing

### DIFF
--- a/packages/pi-continuous-learning/package.json
+++ b/packages/pi-continuous-learning/package.json
@@ -57,7 +57,8 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "check": "vitest run && eslint src/ && tsc --noEmit",
-    "prepublishOnly": "npm run build && npm run check"
+    "prepublishOnly": "npm run build && npm run check",
+    "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "^0.62.0",


### PR DESCRIPTION
## Summary

- Add `prepack` script that fails fast with a clear error if `dist/` is missing
- Scoped to the package so release-please picks up the `fix` commit and creates a patch release (the prior CI-only fix in #75 wasn't associated with the package path)

## Test plan

- [ ] Merge and verify release-please creates a draft release PR
- [ ] After release, verify published tarball includes `dist/`
