### PR TITLE
feat: add pi-red-green TDD enforcement extension

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "packages/pi-continuous-learning": "0.13.2"
+  "packages/pi-continuous-learning": "0.13.2",
+  "packages/pi-red-green": "0.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,6 +4027,10 @@
       "resolved": "packages/pi-continuous-learning",
       "link": true
     },
+    "node_modules/pi-red-green": {
+      "resolved": "packages/pi-red-green",
+      "link": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -5010,6 +5014,27 @@
       "optionalDependencies": {
         "@esbuild/linux-x64": "0.27.4",
         "@rollup/rollup-linux-x64-gnu": "4.60.0"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-coding-agent": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.62.0",
+        "@sinclair/typebox": "^0.34.0"
+      }
+    },
+    "packages/pi-red-green": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "@mariozechner/pi-ai": "^0.62.0",

--- a/packages/pi-red-green/README.md
+++ b/packages/pi-red-green/README.md
@@ -1,0 +1,114 @@
+# pi-red-green
+
+TDD enforcement for [Pi coding agent](https://github.com/nicepkg/pi) sessions. Forces agents to follow the RED-GREEN-REFACTOR cycle: write failing tests first, implement minimally, then refactor.
+
+## Installation
+
+```bash
+npm install pi-red-green
+```
+
+Add to your Pi config:
+
+```json
+{
+  "extensions": ["pi-red-green"]
+}
+```
+
+## Usage
+
+### Start a TDD session
+
+```
+/tdd Add user authentication
+```
+
+This enters RED phase. The agent's system prompt is modified to enforce writing failing tests first.
+
+### Check status
+
+```
+/tdd-status
+```
+
+Shows current phase, task, file history, test results, and staleness.
+
+### End a TDD session
+
+```
+/tdd off
+```
+
+### Phase cycle
+
+1. **RED**: Write failing tests. Agent is blocked from writing implementation.
+2. **GREEN**: Tests are failing as expected. Write the simplest code to pass.
+3. **REFACTOR**: Tests pass. Clean up without adding behavior.
+4. **COMPLETE**: Cycle done. Start a new task or deactivate.
+
+Phase transitions happen automatically when test runner output is detected (vitest, jest, pytest, go test, cargo test, etc).
+
+## LLM Tools
+
+The extension registers three tools the agent can call:
+
+| Tool | Description |
+|------|-------------|
+| `tdd_status` | Returns current phase, task, file history, test results |
+| `tdd_advance` | Manually advance to next phase (escape hatch) |
+| `tdd_reset` | Reset TDD state to idle |
+
+## Configuration
+
+Create `~/.pi/red-green/config.json` to override defaults:
+
+```json
+{
+  "injection_mode": "active-only",
+  "ordering_enforcement": "warn",
+  "auto_advance": true,
+  "coverage_threshold": 80,
+  "coverage_enabled": false,
+  "test_file_patterns": {
+    "typescript": ["**/*.test.ts", "**/*.spec.ts"],
+    "python": ["**/test_*.py", "**/*_test.py"],
+    "go": ["**/*_test.go"],
+    "rust": ["**/tests/**/*.rs"],
+    "java": ["**/*Test.java", "**/*Spec.java"],
+    "php": ["**/*Test.php"]
+  },
+  "test_runner_patterns": [
+    "vitest", "jest", "pytest", "go test", "cargo test",
+    "phpunit", "mix test", "npm test"
+  ]
+}
+```
+
+### Injection modes
+
+- `active-only` (default): Only inject TDD prompts when `/tdd` is active
+- `always`: Inject TDD guidance on every turn, nudge when idle
+- `nudge`: Inject gentle "consider writing tests first" reminders
+- `off`: No injection
+
+### Ordering enforcement
+
+- `warn` (default): Warn when implementation files are edited before test files
+- `strict`: Instruct the agent to delete implementation and start over with tests
+- `off`: No enforcement
+
+## Storage
+
+Runtime data lives under `~/.pi/red-green/`:
+
+```
+~/.pi/red-green/
+  config.json     # User config overrides
+  state.json      # Current TDD state (survives session restarts)
+  history.jsonl   # Completed TDD cycles
+```
+
+## License
+
+MIT

--- a/packages/pi-red-green/package.json
+++ b/packages/pi-red-green/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "pi-red-green",
+  "version": "0.1.0",
+  "description": "A Pi extension that enforces Test-Driven Development (RED-GREEN-REFACTOR) discipline during agent coding sessions.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Matt Devy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MattDevy/pi-extensions.git",
+    "directory": "packages/pi-red-green"
+  },
+  "homepage": "https://github.com/MattDevy/pi-extensions/tree/main/packages/pi-red-green#readme",
+  "bugs": {
+    "url": "https://github.com/MattDevy/pi-extensions/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "tdd",
+    "red-green-refactor",
+    "test-driven-development",
+    "ai",
+    "llm",
+    "ai-agent",
+    "coding-assistant",
+    "developer-tools"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**/*.test.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "check": "vitest run && eslint src/ && tsc --noEmit",
+    "prepublishOnly": "npm run build && npm run check",
+    "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.62.0",
+    "@mariozechner/pi-ai": "^0.62.0",
+    "@mariozechner/pi-tui": "^0.62.0",
+    "@sinclair/typebox": "^0.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/pi-red-green/src/config.test.ts
+++ b/packages/pi-red-green/src/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, DEFAULT_CONFIG } from "./config.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "rg-config-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+describe("loadConfig", () => {
+  it("returns defaults when config file does not exist", () => {
+    const config = loadConfig(join(tmpBase, "nonexistent.json"));
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("returns defaults when config file is invalid JSON", () => {
+    const badPath = join(tmpBase, "bad.json");
+    writeFileSync(badPath, "not json {{{", "utf-8");
+    const config = loadConfig(badPath);
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("merges partial config with defaults", () => {
+    const partialPath = join(tmpBase, "partial.json");
+    writeFileSync(
+      partialPath,
+      JSON.stringify({ injection_mode: "always", coverage_threshold: 90 }),
+      "utf-8",
+    );
+    const config = loadConfig(partialPath);
+    expect(config.injection_mode).toBe("always");
+    expect(config.coverage_threshold).toBe(90);
+    expect(config.ordering_enforcement).toBe(DEFAULT_CONFIG.ordering_enforcement);
+    expect(config.auto_advance).toBe(DEFAULT_CONFIG.auto_advance);
+  });
+
+  it("merges partial test_file_patterns without losing defaults", () => {
+    const patternPath = join(tmpBase, "patterns.json");
+    writeFileSync(
+      patternPath,
+      JSON.stringify({
+        test_file_patterns: { typescript: ["**/*.spec.ts"] },
+      }),
+      "utf-8",
+    );
+    const config = loadConfig(patternPath);
+    expect(config.test_file_patterns.typescript).toEqual(["**/*.spec.ts"]);
+    expect(config.test_file_patterns.python).toEqual(DEFAULT_CONFIG.test_file_patterns.python);
+  });
+
+  it("ignores unknown fields", () => {
+    const unknownPath = join(tmpBase, "unknown.json");
+    writeFileSync(
+      unknownPath,
+      JSON.stringify({ injection_mode: "nudge", bogus_field: true }),
+      "utf-8",
+    );
+    const config = loadConfig(unknownPath);
+    expect(config.injection_mode).toBe("nudge");
+    expect((config as unknown as Record<string, unknown>)["bogus_field"]).toBeUndefined();
+  });
+
+  it("ignores invalid enum values and uses defaults", () => {
+    const invalidPath = join(tmpBase, "invalid-enum.json");
+    writeFileSync(
+      invalidPath,
+      JSON.stringify({ injection_mode: "banana" }),
+      "utf-8",
+    );
+    const config = loadConfig(invalidPath);
+    expect(config.injection_mode).toBe(DEFAULT_CONFIG.injection_mode);
+  });
+});

--- a/packages/pi-red-green/src/config.ts
+++ b/packages/pi-red-green/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { Type } from "@sinclair/typebox";
@@ -87,15 +87,10 @@ type PartialConfig = {
 };
 
 export function loadConfig(configPath = CONFIG_PATH): TddConfig {
-  if (!existsSync(configPath)) {
-    return { ...DEFAULT_CONFIG };
-  }
-
   let raw: string;
   try {
     raw = readFileSync(configPath, "utf-8");
   } catch {
-    console.warn("[pi-red-green] Failed to read config.json, using defaults");
     return { ...DEFAULT_CONFIG };
   }
 

--- a/packages/pi-red-green/src/config.ts
+++ b/packages/pi-red-green/src/config.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import type { TddConfig, InjectionMode, EnforcementLevel, TestFilePatterns } from "./types.js";
+
+export const CONFIG_DIR = join(homedir(), ".pi", "red-green");
+export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+
+const DEFAULT_TEST_FILE_PATTERNS: TestFilePatterns = {
+  typescript: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx"],
+  python: ["**/test_*.py", "**/*_test.py"],
+  go: ["**/*_test.go"],
+  rust: ["**/tests/**/*.rs"],
+  java: ["**/*Test.java", "**/*Spec.java"],
+  php: ["**/*Test.php"],
+};
+
+const DEFAULT_TEST_RUNNER_PATTERNS: readonly string[] = [
+  "vitest",
+  "jest",
+  "pytest",
+  "go test",
+  "cargo test",
+  "phpunit",
+  "mix test",
+  "dotnet test",
+  "mvn test",
+  "gradle test",
+  "npm test",
+  "npm run test",
+  "npx vitest",
+  "npx jest",
+];
+
+export const DEFAULT_CONFIG: TddConfig = {
+  injection_mode: "active-only",
+  ordering_enforcement: "warn",
+  coverage_threshold: 80,
+  coverage_enabled: false,
+  auto_advance: true,
+  test_file_patterns: DEFAULT_TEST_FILE_PATTERNS,
+  test_runner_patterns: DEFAULT_TEST_RUNNER_PATTERNS,
+};
+
+const TestFilePatternsSchema = Type.Partial(
+  Type.Object({
+    typescript: Type.Array(Type.String()),
+    python: Type.Array(Type.String()),
+    go: Type.Array(Type.String()),
+    rust: Type.Array(Type.String()),
+    java: Type.Array(Type.String()),
+    php: Type.Array(Type.String()),
+  }),
+);
+
+const PartialConfigSchema = Type.Partial(
+  Type.Object({
+    injection_mode: Type.Union([
+      Type.Literal("always"),
+      Type.Literal("active-only"),
+      Type.Literal("nudge"),
+      Type.Literal("off"),
+    ]),
+    ordering_enforcement: Type.Union([
+      Type.Literal("warn"),
+      Type.Literal("strict"),
+      Type.Literal("off"),
+    ]),
+    coverage_threshold: Type.Number({ minimum: 0, maximum: 100 }),
+    coverage_enabled: Type.Boolean(),
+    auto_advance: Type.Boolean(),
+    test_file_patterns: TestFilePatternsSchema,
+    test_runner_patterns: Type.Array(Type.String()),
+  }),
+);
+
+type PartialConfig = {
+  injection_mode?: TddConfig["injection_mode"];
+  ordering_enforcement?: TddConfig["ordering_enforcement"];
+  coverage_threshold?: number;
+  coverage_enabled?: boolean;
+  auto_advance?: boolean;
+  test_file_patterns?: Partial<TestFilePatterns>;
+  test_runner_patterns?: readonly string[];
+};
+
+export function loadConfig(configPath = CONFIG_PATH): TddConfig {
+  if (!existsSync(configPath)) {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    console.warn("[pi-red-green] Failed to read config.json, using defaults");
+    return { ...DEFAULT_CONFIG };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn("[pi-red-green] Invalid JSON in config.json, using defaults");
+    return { ...DEFAULT_CONFIG };
+  }
+
+  const cleaned = Value.Clean(PartialConfigSchema, parsed) as PartialConfig;
+
+  const VALID_INJECTION_MODES: readonly InjectionMode[] = ["always", "active-only", "nudge", "off"];
+  const VALID_ENFORCEMENT_LEVELS: readonly EnforcementLevel[] = ["warn", "strict", "off"];
+
+  const injectionMode = cleaned.injection_mode !== undefined
+    && VALID_INJECTION_MODES.includes(cleaned.injection_mode)
+    ? cleaned.injection_mode
+    : DEFAULT_CONFIG.injection_mode;
+
+  const orderingEnforcement = cleaned.ordering_enforcement !== undefined
+    && VALID_ENFORCEMENT_LEVELS.includes(cleaned.ordering_enforcement)
+    ? cleaned.ordering_enforcement
+    : DEFAULT_CONFIG.ordering_enforcement;
+
+  const mergedPatterns: TestFilePatterns = cleaned.test_file_patterns
+    ? { ...DEFAULT_TEST_FILE_PATTERNS, ...cleaned.test_file_patterns }
+    : DEFAULT_TEST_FILE_PATTERNS;
+
+  return {
+    ...DEFAULT_CONFIG,
+    ...cleaned,
+    injection_mode: injectionMode,
+    ordering_enforcement: orderingEnforcement,
+    test_file_patterns: mergedPatterns,
+  };
+}

--- a/packages/pi-red-green/src/file-classifier.test.ts
+++ b/packages/pi-red-green/src/file-classifier.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { classifyFile, detectLanguage } from "./file-classifier.js";
+import { DEFAULT_CONFIG } from "./config.js";
+
+describe("detectLanguage", () => {
+  it("detects TypeScript", () => {
+    expect(detectLanguage("src/auth.ts")).toBe("typescript");
+    expect(detectLanguage("App.tsx")).toBe("typescript");
+  });
+
+  it("detects JavaScript as typescript", () => {
+    expect(detectLanguage("index.js")).toBe("typescript");
+    expect(detectLanguage("App.jsx")).toBe("typescript");
+  });
+
+  it("detects Python", () => {
+    expect(detectLanguage("main.py")).toBe("python");
+  });
+
+  it("detects Go", () => {
+    expect(detectLanguage("handler.go")).toBe("go");
+  });
+
+  it("detects Rust", () => {
+    expect(detectLanguage("lib.rs")).toBe("rust");
+  });
+
+  it("detects Java", () => {
+    expect(detectLanguage("UserService.java")).toBe("java");
+  });
+
+  it("detects PHP", () => {
+    expect(detectLanguage("Controller.php")).toBe("php");
+  });
+
+  it("returns null for unknown extensions", () => {
+    expect(detectLanguage("data.csv")).toBeNull();
+    expect(detectLanguage("README.md")).toBeNull();
+  });
+});
+
+describe("classifyFile", () => {
+  const config = DEFAULT_CONFIG;
+
+  describe("TypeScript test files", () => {
+    it("classifies .test.ts as test", () => {
+      expect(classifyFile("src/auth.test.ts", config)).toBe("test");
+    });
+
+    it("classifies .spec.ts as test", () => {
+      expect(classifyFile("src/auth.spec.ts", config)).toBe("test");
+    });
+
+    it("classifies .test.tsx as test", () => {
+      expect(classifyFile("components/Button.test.tsx", config)).toBe("test");
+    });
+
+    it("classifies nested test files", () => {
+      expect(classifyFile("packages/core/src/utils.test.ts", config)).toBe("test");
+    });
+  });
+
+  describe("Python test files", () => {
+    it("classifies test_ prefix as test", () => {
+      expect(classifyFile("tests/test_auth.py", config)).toBe("test");
+    });
+
+    it("classifies _test suffix as test", () => {
+      expect(classifyFile("tests/auth_test.py", config)).toBe("test");
+    });
+  });
+
+  describe("Go test files", () => {
+    it("classifies _test.go as test", () => {
+      expect(classifyFile("handler_test.go", config)).toBe("test");
+    });
+  });
+
+  describe("Rust test files", () => {
+    it("classifies files under tests/ as test", () => {
+      expect(classifyFile("src/tests/integration.rs", config)).toBe("test");
+    });
+  });
+
+  describe("Java test files", () => {
+    it("classifies *Test.java as test", () => {
+      expect(classifyFile("src/test/UserServiceTest.java", config)).toBe("test");
+    });
+
+    it("classifies *Spec.java as test", () => {
+      expect(classifyFile("src/test/UserServiceSpec.java", config)).toBe("test");
+    });
+  });
+
+  describe("Implementation files", () => {
+    it("classifies regular .ts as implementation", () => {
+      expect(classifyFile("src/auth.ts", config)).toBe("implementation");
+    });
+
+    it("classifies regular .py as implementation", () => {
+      expect(classifyFile("src/auth.py", config)).toBe("implementation");
+    });
+
+    it("classifies regular .go as implementation", () => {
+      expect(classifyFile("cmd/server.go", config)).toBe("implementation");
+    });
+  });
+
+  describe("Other files", () => {
+    it("classifies JSON as other", () => {
+      expect(classifyFile("package.json", config)).toBe("other");
+    });
+
+    it("classifies markdown as other", () => {
+      expect(classifyFile("README.md", config)).toBe("other");
+    });
+
+    it("classifies CSS as other", () => {
+      expect(classifyFile("styles.css", config)).toBe("other");
+    });
+
+    it("classifies config files as other", () => {
+      expect(classifyFile("tsconfig.json", config)).toBe("other");
+      expect(classifyFile("vitest.config.ts", config)).toBe("other");
+      expect(classifyFile("eslint.config.js", config)).toBe("other");
+      expect(classifyFile("Makefile", config)).toBe("other");
+      expect(classifyFile("Dockerfile", config)).toBe("other");
+    });
+
+    it("classifies lock files as other", () => {
+      expect(classifyFile("package-lock.json", config)).toBe("other");
+    });
+
+    it("classifies dotfiles as other", () => {
+      expect(classifyFile(".gitignore", config)).toBe("other");
+      expect(classifyFile(".env", config)).toBe("other");
+    });
+  });
+
+  describe("Windows paths", () => {
+    it("normalizes backslashes", () => {
+      expect(classifyFile("src\\auth.test.ts", config)).toBe("test");
+      expect(classifyFile("src\\auth.ts", config)).toBe("implementation");
+    });
+  });
+});

--- a/packages/pi-red-green/src/file-classifier.ts
+++ b/packages/pi-red-green/src/file-classifier.ts
@@ -41,15 +41,12 @@ export function detectLanguage(filePath: string): string | null {
   return null;
 }
 
-function matchesAnyPattern(filePath: string, patterns: readonly string[]): boolean {
-  const normalized = filePath.replace(/\\/g, "/");
-  for (const pattern of patterns) {
-    if (matchGlobSimple(normalized, pattern)) return true;
-  }
-  return false;
-}
+const globRegexCache = new Map<string, RegExp>();
 
-function globToRegex(pattern: string): RegExp {
+function getGlobRegex(pattern: string): RegExp {
+  let cached = globRegexCache.get(pattern);
+  if (cached) return cached;
+
   const escaped = pattern
     .replace(/[.+^${}()|[\]\\]/g, "\\$&")
     .replace(/\*\*\//g, "(__GLOBSTAR__/)?")
@@ -57,11 +54,17 @@ function globToRegex(pattern: string): RegExp {
     .replace(/\*/g, "[^/]*")
     .replace(/__GLOBSTAR__/g, ".*");
 
-  return new RegExp(`(^|/)${escaped}$`);
+  cached = new RegExp(`(^|/)${escaped}$`);
+  globRegexCache.set(pattern, cached);
+  return cached;
 }
 
-function matchGlobSimple(filePath: string, pattern: string): boolean {
-  return globToRegex(pattern).test(filePath);
+function matchesAnyPattern(filePath: string, patterns: readonly string[]): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  for (const pattern of patterns) {
+    if (getGlobRegex(pattern).test(normalized)) return true;
+  }
+  return false;
 }
 
 export function classifyFile(
@@ -70,12 +73,10 @@ export function classifyFile(
 ): FileClassification {
   const normalized = filePath.replace(/\\/g, "/");
 
-  // Check for non-source file extensions
   for (const ext of OTHER_EXTENSIONS) {
     if (normalized.toLowerCase().endsWith(ext)) return "other";
   }
 
-  // Check for config/build files by name
   const segments = normalized.split("/");
   const filename = segments[segments.length - 1] ?? "";
   if (isConfigFile(filename)) return "other";

--- a/packages/pi-red-green/src/file-classifier.ts
+++ b/packages/pi-red-green/src/file-classifier.ts
@@ -1,0 +1,118 @@
+import type { TddConfig } from "./types.js";
+
+export type FileClassification = "test" | "implementation" | "other";
+
+const LANGUAGE_MAP: Record<string, string> = {
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".js": "typescript",
+  ".jsx": "typescript",
+  ".py": "python",
+  ".go": "go",
+  ".rs": "rust",
+  ".java": "java",
+  ".php": "php",
+};
+
+const OTHER_EXTENSIONS = new Set([
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".md",
+  ".txt",
+  ".css",
+  ".scss",
+  ".html",
+  ".svg",
+  ".png",
+  ".jpg",
+  ".lock",
+  ".env",
+  ".gitignore",
+  ".editorconfig",
+]);
+
+export function detectLanguage(filePath: string): string | null {
+  const lower = filePath.toLowerCase();
+  for (const [ext, lang] of Object.entries(LANGUAGE_MAP)) {
+    if (lower.endsWith(ext)) return lang;
+  }
+  return null;
+}
+
+function matchesAnyPattern(filePath: string, patterns: readonly string[]): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  for (const pattern of patterns) {
+    if (matchGlobSimple(normalized, pattern)) return true;
+  }
+  return false;
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*\//g, "(__GLOBSTAR__/)?")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*")
+    .replace(/__GLOBSTAR__/g, ".*");
+
+  return new RegExp(`(^|/)${escaped}$`);
+}
+
+function matchGlobSimple(filePath: string, pattern: string): boolean {
+  return globToRegex(pattern).test(filePath);
+}
+
+export function classifyFile(
+  filePath: string,
+  config: TddConfig,
+): FileClassification {
+  const normalized = filePath.replace(/\\/g, "/");
+
+  // Check for non-source file extensions
+  for (const ext of OTHER_EXTENSIONS) {
+    if (normalized.toLowerCase().endsWith(ext)) return "other";
+  }
+
+  // Check for config/build files by name
+  const segments = normalized.split("/");
+  const filename = segments[segments.length - 1] ?? "";
+  if (isConfigFile(filename)) return "other";
+
+  const language = detectLanguage(filePath);
+  if (!language) return "other";
+
+  const patterns = config.test_file_patterns[language as keyof typeof config.test_file_patterns];
+  if (patterns && matchesAnyPattern(normalized, patterns)) {
+    return "test";
+  }
+
+  return "implementation";
+}
+
+function isConfigFile(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return (
+    lower.startsWith("tsconfig") ||
+    lower.startsWith("vitest.config") ||
+    lower.startsWith("jest.config") ||
+    lower.startsWith("eslint") ||
+    lower.startsWith(".eslint") ||
+    lower.startsWith("prettier") ||
+    lower.startsWith(".prettier") ||
+    lower === "package.json" ||
+    lower === "package-lock.json" ||
+    lower === "makefile" ||
+    lower === "dockerfile" ||
+    lower === "cargo.toml" ||
+    lower === "go.mod" ||
+    lower === "go.sum" ||
+    lower === "build.gradle" ||
+    lower === "build.gradle.kts" ||
+    lower === "pom.xml" ||
+    lower === "pyproject.toml" ||
+    lower === "setup.py" ||
+    lower === "setup.cfg"
+  );
+}

--- a/packages/pi-red-green/src/index.test.ts
+++ b/packages/pi-red-green/src/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import extension from "./index.js";
+
+function makeMockPi(): ExtensionAPI {
+  return {
+    on: vi.fn(),
+    registerCommand: vi.fn(),
+    registerTool: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as ExtensionAPI;
+}
+
+describe("extension entry point", () => {
+  let pi: ExtensionAPI;
+
+  beforeEach(() => {
+    pi = makeMockPi();
+    extension(pi);
+  });
+
+  it("registers 5 event handlers", () => {
+    expect(vi.mocked(pi.on)).toHaveBeenCalledTimes(5);
+  });
+
+  it("registers session_start handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("session_start");
+  });
+
+  it("registers session_shutdown handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("session_shutdown");
+  });
+
+  it("registers before_agent_start handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("before_agent_start");
+  });
+
+  it("registers tool_execution_end handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("tool_execution_end");
+  });
+
+  it("registers turn_end handler", () => {
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("turn_end");
+  });
+
+  it("registers 2 commands", () => {
+    expect(vi.mocked(pi.registerCommand)).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers tdd command", () => {
+    const commands = vi.mocked(pi.registerCommand).mock.calls.map(([name]) => name);
+    expect(commands).toContain("tdd");
+  });
+
+  it("registers tdd-status command", () => {
+    const commands = vi.mocked(pi.registerCommand).mock.calls.map(([name]) => name);
+    expect(commands).toContain("tdd-status");
+  });
+});

--- a/packages/pi-red-green/src/index.ts
+++ b/packages/pi-red-green/src/index.ts
@@ -10,6 +10,7 @@ import { classifyFile } from "./file-classifier.js";
 import { isTestRunCommand, parseTestRunResult } from "./test-run-detector.js";
 import {
   handleBeforeAgentStart as buildInjection,
+  type BeforeAgentStartEvent,
 } from "./tdd-injector.js";
 import { updateStatusBar } from "./status-bar.js";
 import { handleTddCommand, COMMAND_NAME as TDD_CMD } from "./tdd-command.js";
@@ -25,7 +26,6 @@ export default function (pi: ExtensionAPI): void {
   let config: TddConfig | null = null;
   let state: TddState | null = null;
 
-  // Shared accessors for commands/tools to read and write state
   const stateRef = {
     get: (): TddState | null => state,
     set: (s: TddState) => {
@@ -62,7 +62,7 @@ export default function (pi: ExtensionAPI): void {
     try {
       if (!state || !config) return;
       return buildInjection(
-        event as { type: "before_agent_start"; prompt: string; systemPrompt: string },
+        event as BeforeAgentStartEvent,
         state,
         config,
       ) ?? undefined;
@@ -83,7 +83,6 @@ export default function (pi: ExtensionAPI): void {
         isError: boolean;
       };
 
-      // Classify file edits
       if (toolName === "Write" || toolName === "Edit") {
         const filePath = extractFilePath(result);
         if (filePath) {
@@ -99,7 +98,6 @@ export default function (pi: ExtensionAPI): void {
         }
       }
 
-      // Detect test runs
       if (toolName === "Bash" && !isError) {
         const { stdout, stderr, exitCode, command } = extractBashResult(result);
         if (command && isTestRunCommand(command, config)) {
@@ -111,7 +109,6 @@ export default function (pi: ExtensionAPI): void {
             };
             state = { ...state, last_test_run: updatedResult };
 
-            // Auto-advance if enabled
             if (config.auto_advance) {
               const trigger =
                 updatedResult.errors > 0
@@ -148,7 +145,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("turn_end", (_event, _ctx) => {
     try {
-      if (!state) return;
+      if (!state || state.phase === "idle") return;
       state = { ...state, current_turn_index: state.current_turn_index + 1 };
       saveState(state);
     } catch (err) {
@@ -169,10 +166,11 @@ export default function (pi: ExtensionAPI): void {
   });
 }
 
+const FILE_PATH_RE = /(?:File|file|path)[:\s]+(\S+)/;
+
 function extractFilePath(result: unknown): string | null {
   if (typeof result === "string") {
-    // Try to extract file path from tool result text
-    const match = result.match(/(?:File|file|path)[:\s]+(\S+)/);
+    const match = result.match(FILE_PATH_RE);
     return match?.[1] ?? null;
   }
   if (result && typeof result === "object") {

--- a/packages/pi-red-green/src/index.ts
+++ b/packages/pi-red-green/src/index.ts
@@ -1,0 +1,203 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+
+import { loadConfig } from "./config.js";
+import { ensureStorageLayout, loadState, saveState } from "./storage.js";
+import { advancePhase } from "./state-machine.js";
+import { classifyFile } from "./file-classifier.js";
+import { isTestRunCommand, parseTestRunResult } from "./test-run-detector.js";
+import {
+  handleBeforeAgentStart as buildInjection,
+} from "./tdd-injector.js";
+import { updateStatusBar } from "./status-bar.js";
+import { handleTddCommand, COMMAND_NAME as TDD_CMD } from "./tdd-command.js";
+import {
+  handleTddStatusCommand,
+  COMMAND_NAME as TDD_STATUS_CMD,
+} from "./tdd-status-command.js";
+import { registerTddTools } from "./tdd-tools.js";
+import type { TddConfig, TddState } from "./types.js";
+import { createIdleState } from "./state-machine.js";
+
+export default function (pi: ExtensionAPI): void {
+  let config: TddConfig | null = null;
+  let state: TddState | null = null;
+
+  // Shared accessors for commands/tools to read and write state
+  const stateRef = {
+    get: (): TddState | null => state,
+    set: (s: TddState) => {
+      state = s;
+    },
+    getConfig: (): TddConfig | null => config,
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    try {
+      config = loadConfig();
+      ensureStorageLayout();
+      state = loadState() ?? createIdleState("", "");
+
+      registerTddTools(pi, stateRef);
+
+      if (state.phase !== "idle") {
+        updateStatusBar(ctx, state);
+      }
+    } catch (err) {
+      console.error("[pi-red-green] session_start error:", err);
+    }
+  });
+
+  pi.on("session_shutdown", (_event, _ctx) => {
+    try {
+      if (state) saveState(state);
+    } catch (err) {
+      console.error("[pi-red-green] session_shutdown error:", err);
+    }
+  });
+
+  pi.on("before_agent_start", (event, _ctx) => {
+    try {
+      if (!state || !config) return;
+      return buildInjection(
+        event as { type: "before_agent_start"; prompt: string; systemPrompt: string },
+        state,
+        config,
+      ) ?? undefined;
+    } catch (err) {
+      console.error("[pi-red-green] before_agent_start error:", err);
+    }
+  });
+
+  pi.on("tool_execution_end", (event, ctx) => {
+    try {
+      if (!state || !config || state.phase === "idle") return;
+
+      const { toolName, result, isError } = event as {
+        type: "tool_execution_end";
+        toolCallId: string;
+        toolName: string;
+        result: unknown;
+        isError: boolean;
+      };
+
+      // Classify file edits
+      if (toolName === "Write" || toolName === "Edit") {
+        const filePath = extractFilePath(result);
+        if (filePath) {
+          const classification = classifyFile(filePath, config);
+          if (classification === "test" && !state.test_files.includes(filePath)) {
+            state = { ...state, test_files: [...state.test_files, filePath] };
+          } else if (
+            classification === "implementation" &&
+            !state.impl_files.includes(filePath)
+          ) {
+            state = { ...state, impl_files: [...state.impl_files, filePath] };
+          }
+        }
+      }
+
+      // Detect test runs
+      if (toolName === "Bash" && !isError) {
+        const { stdout, stderr, exitCode, command } = extractBashResult(result);
+        if (command && isTestRunCommand(command, config)) {
+          const testResult = parseTestRunResult(stdout, stderr, exitCode);
+          if (testResult) {
+            const updatedResult = {
+              ...testResult,
+              turn_index: state.current_turn_index,
+            };
+            state = { ...state, last_test_run: updatedResult };
+
+            // Auto-advance if enabled
+            if (config.auto_advance) {
+              const trigger =
+                updatedResult.errors > 0
+                  ? "tests_error" as const
+                  : updatedResult.failed > 0
+                    ? "tests_fail" as const
+                    : "tests_pass" as const;
+
+              const previousPhase = state.phase;
+              const transition = advancePhase(state, trigger);
+              state = transition.state;
+
+              if (transition.warning) {
+                ctx.ui.notify(transition.warning, "warning");
+              }
+
+              if (state.phase !== previousPhase) {
+                ctx.ui.notify(
+                  `TDD phase: ${previousPhase.toUpperCase()} -> ${state.phase.toUpperCase()}`,
+                  "info",
+                );
+                updateStatusBar(ctx, state);
+              }
+            }
+
+            saveState(state);
+          }
+        }
+      }
+    } catch (err) {
+      console.error("[pi-red-green] tool_execution_end error:", err);
+    }
+  });
+
+  pi.on("turn_end", (_event, _ctx) => {
+    try {
+      if (!state) return;
+      state = { ...state, current_turn_index: state.current_turn_index + 1 };
+      saveState(state);
+    } catch (err) {
+      console.error("[pi-red-green] turn_end error:", err);
+    }
+  });
+
+  pi.registerCommand(TDD_CMD, {
+    description: "Start, stop, or show TDD mode",
+    handler: (args: string, ctx: ExtensionCommandContext) =>
+      handleTddCommand(args, ctx, stateRef),
+  });
+
+  pi.registerCommand(TDD_STATUS_CMD, {
+    description: "Show detailed TDD status",
+    handler: (args: string, ctx: ExtensionCommandContext) =>
+      handleTddStatusCommand(args, ctx, stateRef),
+  });
+}
+
+function extractFilePath(result: unknown): string | null {
+  if (typeof result === "string") {
+    // Try to extract file path from tool result text
+    const match = result.match(/(?:File|file|path)[:\s]+(\S+)/);
+    return match?.[1] ?? null;
+  }
+  if (result && typeof result === "object") {
+    const obj = result as Record<string, unknown>;
+    if (typeof obj["file_path"] === "string") return obj["file_path"];
+    if (typeof obj["path"] === "string") return obj["path"];
+  }
+  return null;
+}
+
+interface BashResultShape {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  command: string;
+}
+
+function extractBashResult(result: unknown): BashResultShape {
+  const empty = { stdout: "", stderr: "", exitCode: 0, command: "" };
+  if (!result || typeof result !== "object") return empty;
+  const obj = result as Record<string, unknown>;
+  return {
+    stdout: typeof obj["stdout"] === "string" ? obj["stdout"] : "",
+    stderr: typeof obj["stderr"] === "string" ? obj["stderr"] : "",
+    exitCode: typeof obj["exitCode"] === "number" ? obj["exitCode"] : 0,
+    command: typeof obj["command"] === "string" ? obj["command"] : "",
+  };
+}

--- a/packages/pi-red-green/src/index.ts
+++ b/packages/pi-red-green/src/index.ts
@@ -156,7 +156,7 @@ export default function (pi: ExtensionAPI): void {
   pi.registerCommand(TDD_CMD, {
     description: "Start, stop, or show TDD mode",
     handler: (args: string, ctx: ExtensionCommandContext) =>
-      handleTddCommand(args, ctx, stateRef),
+      handleTddCommand(args, ctx, stateRef, pi),
   });
 
   pi.registerCommand(TDD_STATUS_CMD, {

--- a/packages/pi-red-green/src/prompts/green-phase.ts
+++ b/packages/pi-red-green/src/prompts/green-phase.ts
@@ -1,0 +1,20 @@
+export function getGreenPhasePrompt(task: string, failedCount: number): string {
+  return `## TDD: GREEN Phase -- Make Tests Pass
+
+**Task:** ${task}
+**Failing tests:** ${failedCount}
+
+Tests are failing as expected. Write the SIMPLEST code to make them pass.
+
+### Rules
+- Write the minimal implementation to satisfy the failing tests
+- Do not add features beyond what tests require
+- Do not refactor other code
+- Do not "improve" or "clean up" during this phase
+- After writing implementation, RUN tests and confirm they pass
+
+### Anti-patterns
+- Don't add untested features "while you're in there"
+- Don't mock behavior that should be real
+- Don't add test-only methods to production classes`;
+}

--- a/packages/pi-red-green/src/prompts/nudge.ts
+++ b/packages/pi-red-green/src/prompts/nudge.ts
@@ -1,0 +1,3 @@
+export function getNudgePrompt(): string {
+  return `**TDD Reminder:** Consider writing tests first for this change. Test-driven development catches edge cases early and produces more reliable code.`;
+}

--- a/packages/pi-red-green/src/prompts/red-phase.ts
+++ b/packages/pi-red-green/src/prompts/red-phase.ts
@@ -1,0 +1,29 @@
+export function getRedPhasePrompt(task: string): string {
+  return `## TDD: RED Phase -- Write Failing Tests
+
+**Task:** ${task}
+
+Write failing tests for this task. Do NOT write implementation yet.
+
+### Rules
+- Write tests that describe the expected behavior
+- Each test should assert ONE thing
+- Use real code, not mocks, unless external I/O forces it
+- After writing tests, RUN them
+- Confirm they FAIL because the feature is missing, not because of typos or import errors
+- If tests fail with runtime/compile errors, fix the test code first
+
+### Rationalization Prevention
+| Excuse | Rebuttal |
+|--------|----------|
+| "Too simple to test" | Simple code breaks. A test takes 30 seconds. Write it. |
+| "I'll write tests after" | No. Tests first. That's the point. |
+| "Just this once" | There is no "just this once." TDD is a discipline, not a suggestion. |
+| "The types guarantee correctness" | Types don't catch logic errors. Write the test. |
+
+### Verification Gate
+After writing tests, you MUST run them and confirm:
+1. Tests execute without runtime/compile errors
+2. Tests FAIL because the feature is not yet implemented
+3. The failure messages describe the missing behavior`;
+}

--- a/packages/pi-red-green/src/prompts/refactor-phase.ts
+++ b/packages/pi-red-green/src/prompts/refactor-phase.ts
@@ -1,0 +1,13 @@
+export function getRefactorPhasePrompt(task: string): string {
+  return `## TDD: REFACTOR Phase -- Improve Without Breaking
+
+**Task:** ${task}
+
+All tests pass. Refactor if needed: remove duplication, improve names, extract helpers.
+
+### Rules
+- Keep tests green. Do not add new behavior.
+- RUN tests after every refactor to confirm they still pass
+- If a refactoring breaks tests, revert the last change immediately
+- This phase is optional. If the code is clean, advance to the next task.`;
+}

--- a/packages/pi-red-green/src/prompts/warnings.ts
+++ b/packages/pi-red-green/src/prompts/warnings.ts
@@ -1,0 +1,12 @@
+import type { EnforcementLevel } from "../types.js";
+
+export function getStaleTestWarning(): string {
+  return `**Stale test results.** The last test run was in a previous turn. Run tests again before claiming they pass. Fresh evidence required.`;
+}
+
+export function getOrderingWarning(level: EnforcementLevel): string {
+  if (level === "strict") {
+    return `**TDD Violation (strict mode).** Implementation code was written before tests. Delete the implementation and start over with tests first. This is not negotiable.`;
+  }
+  return `**TDD Warning.** Implementation files were edited before any test files in this cycle. Consider writing tests first.`;
+}

--- a/packages/pi-red-green/src/state-machine.test.ts
+++ b/packages/pi-red-green/src/state-machine.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { createInitialState, createIdleState, advancePhase } from "./state-machine.js";
+import type { TddState } from "./types.js";
+
+function makeRedState(overrides: Partial<TddState> = {}): TddState {
+  return {
+    ...createInitialState("Add auth", "sess-1", "proj-1"),
+    ...overrides,
+  };
+}
+
+function makeGreenState(overrides: Partial<TddState> = {}): TddState {
+  return {
+    ...makeRedState(),
+    phase: "green",
+    ...overrides,
+  };
+}
+
+function makeRefactorState(overrides: Partial<TddState> = {}): TddState {
+  return {
+    ...makeRedState(),
+    phase: "refactor",
+    ...overrides,
+  };
+}
+
+function makeCompleteState(overrides: Partial<TddState> = {}): TddState {
+  return {
+    ...makeRedState(),
+    phase: "complete",
+    ...overrides,
+  };
+}
+
+describe("createInitialState", () => {
+  it("creates a state in red phase", () => {
+    const state = createInitialState("Add auth", "sess-1", "proj-1");
+    expect(state.phase).toBe("red");
+    expect(state.task).toBe("Add auth");
+    expect(state.session_id).toBe("sess-1");
+    expect(state.project_id).toBe("proj-1");
+    expect(state.test_files).toEqual([]);
+    expect(state.impl_files).toEqual([]);
+    expect(state.last_test_run).toBeNull();
+    expect(state.phase_history).toHaveLength(1);
+    expect(state.phase_history[0]?.phase).toBe("red");
+    expect(state.current_turn_index).toBe(0);
+  });
+});
+
+describe("createIdleState", () => {
+  it("creates an idle state with no task", () => {
+    const state = createIdleState("sess-1", "proj-1");
+    expect(state.phase).toBe("idle");
+    expect(state.task).toBe("");
+    expect(state.phase_history).toEqual([]);
+  });
+});
+
+describe("advancePhase from RED", () => {
+  it("advances to GREEN on tests_fail", () => {
+    const result = advancePhase(makeRedState(), "tests_fail");
+    expect(result.state.phase).toBe("green");
+    expect(result.warning).toBeNull();
+  });
+
+  it("stays in RED with warning on tests_error", () => {
+    const result = advancePhase(makeRedState(), "tests_error");
+    expect(result.state.phase).toBe("red");
+    expect(result.warning).toContain("Fix the test error");
+  });
+
+  it("stays in RED with warning on tests_pass", () => {
+    const result = advancePhase(makeRedState(), "tests_pass");
+    expect(result.state.phase).toBe("red");
+    expect(result.warning).toContain("Tests should be failing");
+  });
+
+  it("advances to GREEN on manual_advance", () => {
+    const result = advancePhase(makeRedState(), "manual_advance");
+    expect(result.state.phase).toBe("green");
+    expect(result.warning).toBeNull();
+  });
+
+  it("resets to idle on reset", () => {
+    const result = advancePhase(makeRedState(), "reset");
+    expect(result.state.phase).toBe("idle");
+    expect(result.warning).toBeNull();
+  });
+
+  it("appends phase history entry on transition", () => {
+    const result = advancePhase(makeRedState(), "tests_fail");
+    expect(result.state.phase_history.length).toBeGreaterThan(1);
+    const lastEntry = result.state.phase_history[result.state.phase_history.length - 1];
+    expect(lastEntry?.phase).toBe("green");
+  });
+});
+
+describe("advancePhase from GREEN", () => {
+  it("advances to REFACTOR on tests_pass", () => {
+    const result = advancePhase(makeGreenState(), "tests_pass");
+    expect(result.state.phase).toBe("refactor");
+    expect(result.warning).toBeNull();
+  });
+
+  it("stays in GREEN with warning on tests_fail", () => {
+    const result = advancePhase(makeGreenState(), "tests_fail");
+    expect(result.state.phase).toBe("green");
+    expect(result.warning).toContain("Tests still failing");
+  });
+
+  it("stays in GREEN with warning on tests_error", () => {
+    const result = advancePhase(makeGreenState(), "tests_error");
+    expect(result.state.phase).toBe("green");
+    expect(result.warning).toContain("Runtime error");
+  });
+
+  it("advances to REFACTOR on manual_advance", () => {
+    const result = advancePhase(makeGreenState(), "manual_advance");
+    expect(result.state.phase).toBe("refactor");
+    expect(result.warning).toBeNull();
+  });
+
+  it("resets to idle on reset", () => {
+    const result = advancePhase(makeGreenState(), "reset");
+    expect(result.state.phase).toBe("idle");
+  });
+});
+
+describe("advancePhase from REFACTOR", () => {
+  it("advances to COMPLETE on tests_pass", () => {
+    const result = advancePhase(makeRefactorState(), "tests_pass");
+    expect(result.state.phase).toBe("complete");
+    expect(result.warning).toBeNull();
+  });
+
+  it("stays in REFACTOR with warning on tests_fail", () => {
+    const result = advancePhase(makeRefactorState(), "tests_fail");
+    expect(result.state.phase).toBe("refactor");
+    expect(result.warning).toContain("Refactoring broke tests");
+  });
+
+  it("stays in REFACTOR with warning on tests_error", () => {
+    const result = advancePhase(makeRefactorState(), "tests_error");
+    expect(result.state.phase).toBe("refactor");
+    expect(result.warning).toContain("Runtime error");
+  });
+
+  it("advances to COMPLETE on manual_advance", () => {
+    const result = advancePhase(makeRefactorState(), "manual_advance");
+    expect(result.state.phase).toBe("complete");
+    expect(result.warning).toBeNull();
+  });
+
+  it("resets to idle on reset", () => {
+    const result = advancePhase(makeRefactorState(), "reset");
+    expect(result.state.phase).toBe("idle");
+  });
+});
+
+describe("advancePhase from COMPLETE", () => {
+  it("stays in COMPLETE with warning on tests_pass", () => {
+    const result = advancePhase(makeCompleteState(), "tests_pass");
+    expect(result.state.phase).toBe("complete");
+    expect(result.warning).toContain("complete");
+  });
+
+  it("stays in COMPLETE with warning on manual_advance", () => {
+    const result = advancePhase(makeCompleteState(), "manual_advance");
+    expect(result.state.phase).toBe("complete");
+    expect(result.warning).toContain("already complete");
+  });
+
+  it("resets to idle on reset", () => {
+    const result = advancePhase(makeCompleteState(), "reset");
+    expect(result.state.phase).toBe("idle");
+  });
+});
+
+describe("advancePhase from IDLE", () => {
+  it("stays idle with warning on tests_pass", () => {
+    const state = createIdleState("sess-1", "proj-1");
+    const result = advancePhase(state, "tests_pass");
+    expect(result.state.phase).toBe("idle");
+    expect(result.warning).toContain("No active TDD session");
+  });
+
+  it("stays idle on reset (no-op)", () => {
+    const state = createIdleState("sess-1", "proj-1");
+    const result = advancePhase(state, "reset");
+    expect(result.state.phase).toBe("idle");
+    expect(result.warning).toBeNull();
+  });
+});
+
+describe("immutability", () => {
+  it("does not mutate the original state", () => {
+    const original = makeRedState();
+    const result = advancePhase(original, "tests_fail");
+    expect(original.phase).toBe("red");
+    expect(result.state.phase).toBe("green");
+  });
+});

--- a/packages/pi-red-green/src/state-machine.ts
+++ b/packages/pi-red-green/src/state-machine.ts
@@ -1,0 +1,205 @@
+import type {
+  TddPhase,
+  TddState,
+  PhaseTransitionTrigger,
+  PhaseTransitionResult,
+  PhaseHistoryEntry,
+} from "./types.js";
+
+export function createInitialState(
+  task: string,
+  sessionId: string,
+  projectId: string,
+): TddState {
+  const now = new Date().toISOString();
+  return {
+    phase: "red",
+    task,
+    started_at: now,
+    session_id: sessionId,
+    project_id: projectId,
+    test_files: [],
+    impl_files: [],
+    last_test_run: null,
+    phase_history: [{ phase: "red", entered_at: now }],
+    current_turn_index: 0,
+  };
+}
+
+export function createIdleState(
+  sessionId: string,
+  projectId: string,
+): TddState {
+  return {
+    phase: "idle",
+    task: "",
+    started_at: "",
+    session_id: sessionId,
+    project_id: projectId,
+    test_files: [],
+    impl_files: [],
+    last_test_run: null,
+    phase_history: [],
+    current_turn_index: 0,
+  };
+}
+
+function addPhaseEntry(
+  history: readonly PhaseHistoryEntry[],
+  phase: TddPhase,
+): readonly PhaseHistoryEntry[] {
+  return [...history, { phase, entered_at: new Date().toISOString() }];
+}
+
+function transitionFromRed(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  switch (trigger) {
+    case "tests_fail":
+      return {
+        state: { ...state, phase: "green", phase_history: addPhaseEntry(state.phase_history, "green") },
+        warning: null,
+      };
+    case "tests_error":
+      return {
+        state,
+        warning: "Fix the test error (typo? missing import?). Don't write implementation yet.",
+      };
+    case "tests_pass":
+      return {
+        state,
+        warning: "Tests should be failing. You're testing existing behavior, not new behavior. Fix the test to assert the new, unimplemented behavior.",
+      };
+    case "manual_advance":
+      return {
+        state: { ...state, phase: "green", phase_history: addPhaseEntry(state.phase_history, "green") },
+        warning: null,
+      };
+    case "reset":
+      return {
+        state: createIdleState(state.session_id, state.project_id),
+        warning: null,
+      };
+  }
+}
+
+function transitionFromGreen(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  switch (trigger) {
+    case "tests_pass":
+      return {
+        state: { ...state, phase: "refactor", phase_history: addPhaseEntry(state.phase_history, "refactor") },
+        warning: null,
+      };
+    case "tests_fail":
+      return {
+        state,
+        warning: "Tests still failing. Continue implementing.",
+      };
+    case "tests_error":
+      return {
+        state,
+        warning: "Runtime error in implementation. Fix it.",
+      };
+    case "manual_advance":
+      return {
+        state: { ...state, phase: "refactor", phase_history: addPhaseEntry(state.phase_history, "refactor") },
+        warning: null,
+      };
+    case "reset":
+      return {
+        state: createIdleState(state.session_id, state.project_id),
+        warning: null,
+      };
+  }
+}
+
+function transitionFromRefactor(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  switch (trigger) {
+    case "tests_pass":
+      return {
+        state: { ...state, phase: "complete", phase_history: addPhaseEntry(state.phase_history, "complete") },
+        warning: null,
+      };
+    case "tests_fail":
+      return {
+        state,
+        warning: "Refactoring broke tests. Revert the last change.",
+      };
+    case "tests_error":
+      return {
+        state,
+        warning: "Runtime error after refactoring. Revert the last change.",
+      };
+    case "manual_advance":
+      return {
+        state: { ...state, phase: "complete", phase_history: addPhaseEntry(state.phase_history, "complete") },
+        warning: null,
+      };
+    case "reset":
+      return {
+        state: createIdleState(state.session_id, state.project_id),
+        warning: null,
+      };
+  }
+}
+
+function transitionFromComplete(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  switch (trigger) {
+    case "reset":
+      return {
+        state: createIdleState(state.session_id, state.project_id),
+        warning: null,
+      };
+    case "manual_advance":
+      return {
+        state,
+        warning: "TDD cycle is already complete. Use /tdd to start a new task or /tdd off to deactivate.",
+      };
+    default:
+      return {
+        state,
+        warning: "TDD cycle is complete. Start a new task with /tdd.",
+      };
+  }
+}
+
+function transitionFromIdle(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  if (trigger === "reset") {
+    return { state, warning: null };
+  }
+  return {
+    state,
+    warning: "No active TDD session. Use /tdd to start one.",
+  };
+}
+
+export function advancePhase(
+  state: TddState,
+  trigger: PhaseTransitionTrigger,
+): PhaseTransitionResult {
+  switch (state.phase) {
+    case "idle":
+      return transitionFromIdle(state, trigger);
+    case "red":
+      return transitionFromRed(state, trigger);
+    case "green":
+      return transitionFromGreen(state, trigger);
+    case "refactor":
+      return transitionFromRefactor(state, trigger);
+    case "complete":
+      return transitionFromComplete(state, trigger);
+  }
+}

--- a/packages/pi-red-green/src/status-bar.test.ts
+++ b/packages/pi-red-green/src/status-bar.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { formatStatusText, updateStatusBar, clearStatusBar } from "./status-bar.js";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import type { TddState } from "./types.js";
+
+function makeState(overrides: Partial<TddState> = {}): TddState {
+  return { ...createInitialState("Add auth", "s1", "p1"), ...overrides };
+}
+
+describe("formatStatusText", () => {
+  it("formats red phase with task", () => {
+    expect(formatStatusText(makeState({ phase: "red" }))).toBe("TDD: RED - Add auth");
+  });
+
+  it("formats green phase with task", () => {
+    expect(formatStatusText(makeState({ phase: "green" }))).toBe("TDD: GREEN - Add auth");
+  });
+
+  it("formats refactor phase with task", () => {
+    expect(formatStatusText(makeState({ phase: "refactor" }))).toBe("TDD: REFACTOR - Add auth");
+  });
+
+  it("formats complete phase with task", () => {
+    expect(formatStatusText(makeState({ phase: "complete" }))).toBe("TDD: COMPLETE - Add auth");
+  });
+
+  it("formats idle phase without task", () => {
+    expect(formatStatusText(createIdleState("s1", "p1"))).toBe("TDD: IDLE");
+  });
+
+  it("truncates long task descriptions", () => {
+    const longTask = "Implement a comprehensive user authentication system with OAuth2";
+    const result = formatStatusText(makeState({ task: longTask }));
+    expect(result.length).toBeLessThanOrEqual(55);
+    expect(result).toContain("...");
+  });
+});
+
+describe("updateStatusBar", () => {
+  it("calls setStatus with formatted text", () => {
+    const setStatus = vi.fn();
+    const ctx = { ui: { setStatus } };
+    const state = makeState({ phase: "red" });
+    updateStatusBar(ctx, state);
+    expect(setStatus).toHaveBeenCalledWith("pi-red-green", "TDD: RED - Add auth");
+  });
+
+  it("does not throw when setStatus is undefined", () => {
+    const ctx = { ui: {} };
+    const state = makeState();
+    expect(() => updateStatusBar(ctx, state)).not.toThrow();
+  });
+
+  it("does not throw when setStatus throws", () => {
+    const ctx = {
+      ui: {
+        setStatus: () => {
+          throw new Error("not supported");
+        },
+      },
+    };
+    const state = makeState();
+    expect(() => updateStatusBar(ctx, state)).not.toThrow();
+  });
+});
+
+describe("clearStatusBar", () => {
+  it("calls setStatus with empty string", () => {
+    const setStatus = vi.fn();
+    const ctx = { ui: { setStatus } };
+    clearStatusBar(ctx);
+    expect(setStatus).toHaveBeenCalledWith("pi-red-green", undefined);
+  });
+
+  it("does not throw when setStatus is undefined", () => {
+    const ctx = { ui: {} };
+    expect(() => clearStatusBar(ctx)).not.toThrow();
+  });
+});

--- a/packages/pi-red-green/src/status-bar.ts
+++ b/packages/pi-red-green/src/status-bar.ts
@@ -1,0 +1,41 @@
+import type { TddState, TddPhase } from "./types.js";
+
+interface UiContext {
+  ui: {
+    setStatus?: (key: string, text: string | undefined) => void;
+  };
+}
+
+const PHASE_LABELS: Record<TddPhase, string> = {
+  idle: "IDLE",
+  red: "RED",
+  green: "GREEN",
+  refactor: "REFACTOR",
+  complete: "COMPLETE",
+};
+
+export function formatStatusText(state: TddState): string {
+  const label = PHASE_LABELS[state.phase];
+  if (state.phase === "idle" || !state.task) {
+    return `TDD: ${label}`;
+  }
+  const truncatedTask =
+    state.task.length > 40 ? state.task.slice(0, 37) + "..." : state.task;
+  return `TDD: ${label} - ${truncatedTask}`;
+}
+
+export function updateStatusBar(ctx: UiContext, state: TddState): void {
+  try {
+    ctx.ui.setStatus?.("pi-red-green", formatStatusText(state));
+  } catch {
+    // Graceful fallback: setStatus may not be supported
+  }
+}
+
+export function clearStatusBar(ctx: UiContext): void {
+  try {
+    ctx.ui.setStatus?.("pi-red-green", undefined);
+  } catch {
+    // Graceful fallback
+  }
+}

--- a/packages/pi-red-green/src/storage.test.ts
+++ b/packages/pi-red-green/src/storage.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getBaseDir,
+  getStatePath,
+  getHistoryPath,
+  getConfigPath,
+  ensureStorageLayout,
+  loadState,
+  saveState,
+  clearState,
+  appendCycleRecord,
+} from "./storage.js";
+import { createInitialState } from "./state-machine.js";
+import type { TddCycleRecord } from "./types.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "rg-storage-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+describe("path helpers", () => {
+  it("getBaseDir returns a path under ~/.pi/red-green", () => {
+    const base = getBaseDir();
+    expect(base).toContain(".pi");
+    expect(base).toContain("red-green");
+  });
+
+  it("getStatePath returns state.json under base", () => {
+    const p = getStatePath(tmpBase);
+    expect(p).toBe(join(tmpBase, "state.json"));
+  });
+
+  it("getHistoryPath returns history.jsonl under base", () => {
+    const p = getHistoryPath(tmpBase);
+    expect(p).toBe(join(tmpBase, "history.jsonl"));
+  });
+
+  it("getConfigPath returns config.json under base", () => {
+    const p = getConfigPath(tmpBase);
+    expect(p).toBe(join(tmpBase, "config.json"));
+  });
+});
+
+describe("ensureStorageLayout", () => {
+  it("creates base directory if missing", () => {
+    const dir = join(tmpBase, "ensure-test");
+    expect(existsSync(dir)).toBe(false);
+    ensureStorageLayout(dir);
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    const dir = join(tmpBase, "ensure-idem");
+    ensureStorageLayout(dir);
+    ensureStorageLayout(dir);
+    expect(existsSync(dir)).toBe(true);
+  });
+});
+
+describe("loadState / saveState / clearState", () => {
+  it("returns null when state file does not exist", () => {
+    const dir = join(tmpBase, "no-state");
+    ensureStorageLayout(dir);
+    expect(loadState(dir)).toBeNull();
+  });
+
+  it("round-trips state through save and load", () => {
+    const dir = join(tmpBase, "roundtrip");
+    ensureStorageLayout(dir);
+    const state = createInitialState("Add auth", "sess-1", "proj-1");
+    saveState(state, dir);
+    const loaded = loadState(dir);
+    expect(loaded).toEqual(state);
+  });
+
+  it("clearState removes the state file", () => {
+    const dir = join(tmpBase, "clear-test");
+    ensureStorageLayout(dir);
+    const state = createInitialState("Task", "s", "p");
+    saveState(state, dir);
+    expect(loadState(dir)).not.toBeNull();
+    clearState(dir);
+    expect(loadState(dir)).toBeNull();
+  });
+
+  it("clearState is safe when file does not exist", () => {
+    const dir = join(tmpBase, "clear-noop");
+    ensureStorageLayout(dir);
+    expect(() => clearState(dir)).not.toThrow();
+  });
+});
+
+describe("appendCycleRecord", () => {
+  it("appends JSONL lines to history file", () => {
+    const dir = join(tmpBase, "history-test");
+    ensureStorageLayout(dir);
+    const record: TddCycleRecord = {
+      task: "Add auth",
+      session_id: "sess-1",
+      project_id: "proj-1",
+      started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T01:00:00Z",
+      final_phase: "complete",
+      test_files: ["auth.test.ts"],
+      impl_files: ["auth.ts"],
+      phase_history: [
+        { phase: "red", entered_at: "2026-01-01T00:00:00Z" },
+        { phase: "green", entered_at: "2026-01-01T00:15:00Z" },
+        { phase: "refactor", entered_at: "2026-01-01T00:30:00Z" },
+        { phase: "complete", entered_at: "2026-01-01T00:45:00Z" },
+      ],
+    };
+
+    appendCycleRecord(record, dir);
+    appendCycleRecord({ ...record, task: "Add logout" }, dir);
+
+    const raw = readFileSync(getHistoryPath(dir), "utf-8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).task).toBe("Add auth");
+    expect(JSON.parse(lines[1]!).task).toBe("Add logout");
+  });
+});

--- a/packages/pi-red-green/src/storage.test.ts
+++ b/packages/pi-red-green/src/storage.test.ts
@@ -6,7 +6,6 @@ import {
   getBaseDir,
   getStatePath,
   getHistoryPath,
-  getConfigPath,
   ensureStorageLayout,
   loadState,
   saveState,
@@ -39,10 +38,6 @@ describe("path helpers", () => {
     expect(p).toBe(join(tmpBase, "history.jsonl"));
   });
 
-  it("getConfigPath returns config.json under base", () => {
-    const p = getConfigPath(tmpBase);
-    expect(p).toBe(join(tmpBase, "config.json"));
-  });
 });
 
 describe("ensureStorageLayout", () => {

--- a/packages/pi-red-green/src/storage.ts
+++ b/packages/pi-red-green/src/storage.ts
@@ -1,0 +1,68 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { TddState, TddCycleRecord } from "./types.js";
+
+export function getBaseDir(): string {
+  return join(homedir(), ".pi", "red-green");
+}
+
+export function getStatePath(baseDir = getBaseDir()): string {
+  return join(baseDir, "state.json");
+}
+
+export function getHistoryPath(baseDir = getBaseDir()): string {
+  return join(baseDir, "history.jsonl");
+}
+
+export function getConfigPath(baseDir = getBaseDir()): string {
+  return join(baseDir, "config.json");
+}
+
+export function ensureStorageLayout(baseDir = getBaseDir()): void {
+  if (!existsSync(baseDir)) {
+    mkdirSync(baseDir, { recursive: true });
+  }
+}
+
+export function loadState(baseDir = getBaseDir()): TddState | null {
+  const statePath = getStatePath(baseDir);
+  if (!existsSync(statePath)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(statePath, "utf-8");
+    return JSON.parse(raw) as TddState;
+  } catch {
+    console.warn("[pi-red-green] Failed to load state.json, starting fresh");
+    return null;
+  }
+}
+
+export function saveState(state: TddState, baseDir = getBaseDir()): void {
+  const statePath = getStatePath(baseDir);
+  writeFileSync(statePath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+export function clearState(baseDir = getBaseDir()): void {
+  const statePath = getStatePath(baseDir);
+  if (existsSync(statePath)) {
+    unlinkSync(statePath);
+  }
+}
+
+export function appendCycleRecord(
+  record: TddCycleRecord,
+  baseDir = getBaseDir(),
+): void {
+  const historyPath = getHistoryPath(baseDir);
+  appendFileSync(historyPath, JSON.stringify(record) + "\n", "utf-8");
+}

--- a/packages/pi-red-green/src/storage.ts
+++ b/packages/pi-red-green/src/storage.ts
@@ -1,5 +1,4 @@
 import {
-  existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
@@ -22,27 +21,16 @@ export function getHistoryPath(baseDir = getBaseDir()): string {
   return join(baseDir, "history.jsonl");
 }
 
-export function getConfigPath(baseDir = getBaseDir()): string {
-  return join(baseDir, "config.json");
-}
-
 export function ensureStorageLayout(baseDir = getBaseDir()): void {
-  if (!existsSync(baseDir)) {
-    mkdirSync(baseDir, { recursive: true });
-  }
+  mkdirSync(baseDir, { recursive: true });
 }
 
 export function loadState(baseDir = getBaseDir()): TddState | null {
   const statePath = getStatePath(baseDir);
-  if (!existsSync(statePath)) {
-    return null;
-  }
-
   try {
     const raw = readFileSync(statePath, "utf-8");
     return JSON.parse(raw) as TddState;
   } catch {
-    console.warn("[pi-red-green] Failed to load state.json, starting fresh");
     return null;
   }
 }
@@ -54,8 +42,10 @@ export function saveState(state: TddState, baseDir = getBaseDir()): void {
 
 export function clearState(baseDir = getBaseDir()): void {
   const statePath = getStatePath(baseDir);
-  if (existsSync(statePath)) {
+  try {
     unlinkSync(statePath);
+  } catch {
+    // Already absent
   }
 }
 

--- a/packages/pi-red-green/src/tdd-command.test.ts
+++ b/packages/pi-red-green/src/tdd-command.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { handleTddCommand, type StateRef } from "./tdd-command.js";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import type { TddState, TddConfig } from "./types.js";
+import { DEFAULT_CONFIG } from "./config.js";
+import { ensureStorageLayout } from "./storage.js";
+
+// Ensure the real storage dir exists for tests that write to default paths
+beforeAll(() => {
+  ensureStorageLayout();
+});
+
+const tmpBase = mkdtempSync(join(tmpdir(), "rg-cmd-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeMockCtx(): ExtensionCommandContext {
+  return {
+    ui: {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+    },
+    cwd: tmpBase,
+  } as unknown as ExtensionCommandContext;
+}
+
+function makeStateRef(initial: TddState | null = null): StateRef & { current: TddState | null } {
+  const ref = {
+    current: initial,
+    get: () => ref.current,
+    set: (s: TddState) => {
+      ref.current = s;
+    },
+    getConfig: (): TddConfig | null => DEFAULT_CONFIG,
+  };
+  return ref;
+}
+
+describe("handleTddCommand", () => {
+  beforeEach(() => {
+    ensureStorageLayout(tmpBase);
+  });
+
+  it("shows status when no args and TDD is inactive", async () => {
+    const ctx = makeMockCtx();
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    await handleTddCommand("", ctx, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("not active"),
+      "info",
+    );
+  });
+
+  it("shows status when no args and TDD is active", async () => {
+    const ctx = makeMockCtx();
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    await handleTddCommand("", ctx, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("TDD:"),
+      "info",
+    );
+  });
+
+  it("activates TDD with a task description", async () => {
+    const ctx = makeMockCtx();
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    await handleTddCommand("Add user auth", ctx, ref);
+    expect(ref.current?.phase).toBe("red");
+    expect(ref.current?.task).toBe("Add user auth");
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("TDD activated"),
+      "info",
+    );
+  });
+
+  it("deactivates TDD with 'off'", async () => {
+    const ctx = makeMockCtx();
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    await handleTddCommand("off", ctx, ref);
+    expect(ref.current?.phase).toBe("idle");
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("deactivated"),
+      "info",
+    );
+  });
+
+  it("deactivate is case-insensitive", async () => {
+    const ctx = makeMockCtx();
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    await handleTddCommand("OFF", ctx, ref);
+    expect(ref.current?.phase).toBe("idle");
+  });
+
+  it("deactivate when already inactive shows message", async () => {
+    const ctx = makeMockCtx();
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    await handleTddCommand("off", ctx, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("not active"),
+      "info",
+    );
+  });
+
+  it("activating while already active replaces the task", async () => {
+    const ctx = makeMockCtx();
+    const state = createInitialState("Old task", "s1", "p1");
+    const ref = makeStateRef(state);
+    await handleTddCommand("New task", ctx, ref);
+    expect(ref.current?.task).toBe("New task");
+    expect(ref.current?.phase).toBe("red");
+  });
+});

--- a/packages/pi-red-green/src/tdd-command.test.ts
+++ b/packages/pi-red-green/src/tdd-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vites
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { handleTddCommand, type StateRef } from "./tdd-command.js";
 import { createInitialState, createIdleState } from "./state-machine.js";
 import type { TddState, TddConfig } from "./types.js";
@@ -68,7 +68,7 @@ describe("handleTddCommand", () => {
     );
   });
 
-  it("activates TDD with a task description", async () => {
+  it("activates TDD with a task description (no pi)", async () => {
     const ctx = makeMockCtx();
     const ref = makeStateRef(createIdleState("s1", "p1"));
     await handleTddCommand("Add user auth", ctx, ref);
@@ -78,6 +78,19 @@ describe("handleTddCommand", () => {
       expect.stringContaining("TDD activated"),
       "info",
     );
+  });
+
+  it("activates TDD and sends user message when pi is provided", async () => {
+    const ctx = makeMockCtx();
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    const mockPi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    await handleTddCommand("Add user auth", ctx, ref, mockPi);
+    expect(ref.current?.phase).toBe("red");
+    expect(vi.mocked(mockPi.sendUserMessage)).toHaveBeenCalledWith(
+      expect.stringContaining("Add user auth"),
+      { deliverAs: "followUp" },
+    );
+    expect(vi.mocked(ctx.ui.notify)).not.toHaveBeenCalled();
   });
 
   it("deactivates TDD with 'off'", async () => {

--- a/packages/pi-red-green/src/tdd-command.ts
+++ b/packages/pi-red-green/src/tdd-command.ts
@@ -1,8 +1,7 @@
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { createInitialState, createIdleState } from "./state-machine.js";
 import { saveState, clearState, appendCycleRecord } from "./storage.js";
-import { updateStatusBar, clearStatusBar } from "./status-bar.js";
-import { formatStatusText } from "./status-bar.js";
+import { updateStatusBar, clearStatusBar, formatStatusText } from "./status-bar.js";
 import type { TddState, TddConfig, TddCycleRecord } from "./types.js";
 
 export const COMMAND_NAME = "tdd";
@@ -77,7 +76,7 @@ function deactivate(ctx: ExtensionCommandContext, stateRef: StateRef): void {
   ctx.ui.notify("TDD deactivated.", "info");
 }
 
-function recordCycle(state: TddState): void {
+export function recordCycle(state: TddState): void {
   const record: TddCycleRecord = {
     task: state.task,
     session_id: state.session_id,

--- a/packages/pi-red-green/src/tdd-command.ts
+++ b/packages/pi-red-green/src/tdd-command.ts
@@ -1,0 +1,93 @@
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import { saveState, clearState, appendCycleRecord } from "./storage.js";
+import { updateStatusBar, clearStatusBar } from "./status-bar.js";
+import { formatStatusText } from "./status-bar.js";
+import type { TddState, TddConfig, TddCycleRecord } from "./types.js";
+
+export const COMMAND_NAME = "tdd";
+
+export interface StateRef {
+  get: () => TddState | null;
+  set: (s: TddState) => void;
+  getConfig: () => TddConfig | null;
+}
+
+export async function handleTddCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  stateRef: StateRef,
+): Promise<void> {
+  const trimmed = args.trim();
+
+  if (trimmed === "") {
+    return showStatus(ctx, stateRef);
+  }
+
+  if (trimmed.toLowerCase() === "off") {
+    return deactivate(ctx, stateRef);
+  }
+
+  return activate(trimmed, ctx, stateRef);
+}
+
+function showStatus(ctx: ExtensionCommandContext, stateRef: StateRef): void {
+  const state = stateRef.get();
+  if (!state || state.phase === "idle") {
+    ctx.ui.notify("TDD is not active. Use /tdd <task description> to start.", "info");
+    return;
+  }
+  ctx.ui.notify(formatStatusText(state), "info");
+}
+
+function activate(
+  task: string,
+  ctx: ExtensionCommandContext,
+  stateRef: StateRef,
+): void {
+  const currentState = stateRef.get();
+
+  // If already active, record the previous cycle before starting new
+  if (currentState && currentState.phase !== "idle") {
+    recordCycle(currentState);
+  }
+
+  const sessionId = currentState?.session_id ?? "";
+  const projectId = currentState?.project_id ?? "";
+  const newState = createInitialState(task, sessionId, projectId);
+  stateRef.set(newState);
+  saveState(newState);
+  updateStatusBar(ctx, newState);
+  ctx.ui.notify(`TDD activated: ${task}\nPhase: RED -- Write failing tests first.`, "info");
+}
+
+function deactivate(ctx: ExtensionCommandContext, stateRef: StateRef): void {
+  const state = stateRef.get();
+
+  if (!state || state.phase === "idle") {
+    ctx.ui.notify("TDD is not active.", "info");
+    return;
+  }
+
+  recordCycle(state);
+  const idleState = createIdleState(state.session_id, state.project_id);
+  stateRef.set(idleState);
+  clearState();
+  clearStatusBar(ctx);
+  ctx.ui.notify("TDD deactivated.", "info");
+}
+
+function recordCycle(state: TddState): void {
+  const record: TddCycleRecord = {
+    task: state.task,
+    session_id: state.session_id,
+    project_id: state.project_id,
+    started_at: state.started_at,
+    completed_at: new Date().toISOString(),
+    final_phase: state.phase,
+    test_files: state.test_files,
+    impl_files: state.impl_files,
+    phase_history: state.phase_history,
+  };
+  appendCycleRecord(record);
+}

--- a/packages/pi-red-green/src/tdd-command.ts
+++ b/packages/pi-red-green/src/tdd-command.ts
@@ -57,7 +57,7 @@ function activate(
   stateRef.set(newState);
   saveState(newState);
   updateStatusBar(ctx, newState);
-  ctx.ui.notify(`TDD activated: ${task}\nPhase: RED -- Write failing tests first.`, "info");
+  ctx.ui.notify(`TDD activated: ${task}\nPhase: RED -- Send a message to begin. The agent will be guided to write tests first.`, "info");
 }
 
 function deactivate(ctx: ExtensionCommandContext, stateRef: StateRef): void {

--- a/packages/pi-red-green/src/tdd-command.ts
+++ b/packages/pi-red-green/src/tdd-command.ts
@@ -1,4 +1,7 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
 import { createInitialState, createIdleState } from "./state-machine.js";
 import { saveState, clearState, appendCycleRecord } from "./storage.js";
 import { updateStatusBar, clearStatusBar, formatStatusText } from "./status-bar.js";
@@ -16,6 +19,7 @@ export async function handleTddCommand(
   args: string,
   ctx: ExtensionCommandContext,
   stateRef: StateRef,
+  pi?: ExtensionAPI,
 ): Promise<void> {
   const trimmed = args.trim();
 
@@ -27,7 +31,7 @@ export async function handleTddCommand(
     return deactivate(ctx, stateRef);
   }
 
-  return activate(trimmed, ctx, stateRef);
+  return activate(trimmed, ctx, stateRef, pi);
 }
 
 function showStatus(ctx: ExtensionCommandContext, stateRef: StateRef): void {
@@ -43,10 +47,10 @@ function activate(
   task: string,
   ctx: ExtensionCommandContext,
   stateRef: StateRef,
+  pi?: ExtensionAPI,
 ): void {
   const currentState = stateRef.get();
 
-  // If already active, record the previous cycle before starting new
   if (currentState && currentState.phase !== "idle") {
     recordCycle(currentState);
   }
@@ -57,7 +61,18 @@ function activate(
   stateRef.set(newState);
   saveState(newState);
   updateStatusBar(ctx, newState);
-  ctx.ui.notify(`TDD activated: ${task}\nPhase: RED -- Send a message to begin. The agent will be guided to write tests first.`, "info");
+
+  if (pi) {
+    pi.sendUserMessage(
+      `Implement the following using TDD (red-green-refactor): ${task}`,
+      { deliverAs: "followUp" },
+    );
+  } else {
+    ctx.ui.notify(
+      `TDD activated: ${task}\nPhase: RED -- Send a message to begin.`,
+      "info",
+    );
+  }
 }
 
 function deactivate(ctx: ExtensionCommandContext, stateRef: StateRef): void {

--- a/packages/pi-red-green/src/tdd-injector.test.ts
+++ b/packages/pi-red-green/src/tdd-injector.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { buildTddInjectionBlock, handleBeforeAgentStart, isTestRunStale } from "./tdd-injector.js";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import { DEFAULT_CONFIG } from "./config.js";
+import type { TddState, TddConfig } from "./types.js";
+
+function makeConfig(overrides: Partial<TddConfig> = {}): TddConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+function makeState(overrides: Partial<TddState> = {}): TddState {
+  return { ...createInitialState("Add auth", "s1", "p1"), ...overrides };
+}
+
+describe("buildTddInjectionBlock", () => {
+  it("returns null when injection_mode is off", () => {
+    const config = makeConfig({ injection_mode: "off" });
+    const state = makeState();
+    expect(buildTddInjectionBlock(state, config)).toBeNull();
+  });
+
+  it("returns null for idle state in active-only mode", () => {
+    const config = makeConfig({ injection_mode: "active-only" });
+    const state = createIdleState("s1", "p1");
+    expect(buildTddInjectionBlock(state, config)).toBeNull();
+  });
+
+  it("returns nudge prompt for idle state in nudge mode", () => {
+    const config = makeConfig({ injection_mode: "nudge" });
+    const state = createIdleState("s1", "p1");
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("Consider writing tests first");
+  });
+
+  it("returns nudge prompt for idle state in always mode", () => {
+    const config = makeConfig({ injection_mode: "always" });
+    const state = createIdleState("s1", "p1");
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("Consider writing tests first");
+  });
+
+  it("returns RED phase prompt for red state", () => {
+    const config = makeConfig();
+    const state = makeState({ phase: "red" });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("RED Phase");
+    expect(result).toContain("Add auth");
+    expect(result).toContain("Rationalization Prevention");
+  });
+
+  it("returns GREEN phase prompt for green state", () => {
+    const config = makeConfig();
+    const state = makeState({ phase: "green" });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("GREEN Phase");
+    expect(result).toContain("SIMPLEST code");
+  });
+
+  it("returns REFACTOR phase prompt for refactor state", () => {
+    const config = makeConfig();
+    const state = makeState({ phase: "refactor" });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("REFACTOR Phase");
+    expect(result).toContain("Keep tests green");
+  });
+
+  it("returns null for complete state", () => {
+    const config = makeConfig();
+    const state = makeState({ phase: "complete" });
+    expect(buildTddInjectionBlock(state, config)).toBeNull();
+  });
+
+  it("includes staleness warning when test run is from previous turn", () => {
+    const config = makeConfig();
+    const state = makeState({
+      phase: "green",
+      current_turn_index: 5,
+      last_test_run: {
+        timestamp: "2026-01-01T00:00:00Z",
+        turn_index: 3,
+        passed: 0,
+        failed: 2,
+        errors: 0,
+        exit_code: 1,
+      },
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("Stale test results");
+  });
+
+  it("does not include staleness warning for current turn", () => {
+    const config = makeConfig();
+    const state = makeState({
+      phase: "green",
+      current_turn_index: 3,
+      last_test_run: {
+        timestamp: "2026-01-01T00:00:00Z",
+        turn_index: 3,
+        passed: 0,
+        failed: 2,
+        errors: 0,
+        exit_code: 1,
+      },
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).not.toContain("Stale test results");
+  });
+
+  it("includes ordering warning when impl files exist before test files in red phase", () => {
+    const config = makeConfig({ ordering_enforcement: "warn" });
+    const state = makeState({
+      phase: "red",
+      test_files: [],
+      impl_files: ["src/auth.ts"],
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("TDD Warning");
+  });
+
+  it("includes strict ordering warning in strict mode", () => {
+    const config = makeConfig({ ordering_enforcement: "strict" });
+    const state = makeState({
+      phase: "red",
+      test_files: [],
+      impl_files: ["src/auth.ts"],
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).toContain("TDD Violation");
+    expect(result).toContain("Delete the implementation");
+  });
+
+  it("does not include ordering warning when ordering_enforcement is off", () => {
+    const config = makeConfig({ ordering_enforcement: "off" });
+    const state = makeState({
+      phase: "red",
+      test_files: [],
+      impl_files: ["src/auth.ts"],
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).not.toContain("TDD Warning");
+    expect(result).not.toContain("TDD Violation");
+  });
+
+  it("does not include ordering warning in green phase", () => {
+    const config = makeConfig({ ordering_enforcement: "warn" });
+    const state = makeState({
+      phase: "green",
+      test_files: [],
+      impl_files: ["src/auth.ts"],
+    });
+    const result = buildTddInjectionBlock(state, config);
+    expect(result).not.toContain("TDD Warning");
+  });
+});
+
+describe("isTestRunStale", () => {
+  it("returns false when no test run exists", () => {
+    const state = makeState({ last_test_run: null });
+    expect(isTestRunStale(state)).toBe(false);
+  });
+
+  it("returns true when test run is from a previous turn", () => {
+    const state = makeState({
+      current_turn_index: 5,
+      last_test_run: { timestamp: "", turn_index: 3, passed: 0, failed: 0, errors: 0, exit_code: 0 },
+    });
+    expect(isTestRunStale(state)).toBe(true);
+  });
+
+  it("returns false when test run is from the current turn", () => {
+    const state = makeState({
+      current_turn_index: 3,
+      last_test_run: { timestamp: "", turn_index: 3, passed: 0, failed: 0, errors: 0, exit_code: 0 },
+    });
+    expect(isTestRunStale(state)).toBe(false);
+  });
+});
+
+describe("handleBeforeAgentStart", () => {
+  it("returns modified systemPrompt when injection applies", () => {
+    const event = { type: "before_agent_start" as const, prompt: "do stuff", systemPrompt: "base prompt" };
+    const state = makeState({ phase: "red" });
+    const config = makeConfig();
+    const result = handleBeforeAgentStart(event, state, config);
+    expect(result).toBeDefined();
+    expect(result!.systemPrompt).toContain("base prompt");
+    expect(result!.systemPrompt).toContain("RED Phase");
+  });
+
+  it("returns undefined when no injection needed", () => {
+    const event = { type: "before_agent_start" as const, prompt: "do stuff", systemPrompt: "base prompt" };
+    const state = createIdleState("s1", "p1");
+    const config = makeConfig({ injection_mode: "active-only" });
+    const result = handleBeforeAgentStart(event, state, config);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/pi-red-green/src/tdd-injector.ts
+++ b/packages/pi-red-green/src/tdd-injector.ts
@@ -11,33 +11,20 @@ export function buildTddInjectionBlock(
 ): string | null {
   if (config.injection_mode === "off") return null;
 
-  // In active-only mode, only inject when TDD is active (non-idle)
-  if (config.injection_mode === "active-only" && state.phase === "idle") {
-    return null;
-  }
-
-  // In nudge mode with idle state, inject gentle reminder
-  if (config.injection_mode === "nudge" && state.phase === "idle") {
-    return `\n\n${getNudgePrompt()}`;
-  }
-
-  // In always mode with idle state, inject nudge
-  if (config.injection_mode === "always" && state.phase === "idle") {
+  if (state.phase === "idle") {
+    if (config.injection_mode === "active-only") return null;
     return `\n\n${getNudgePrompt()}`;
   }
 
   const parts: string[] = [];
 
-  // Phase-specific prompt
   const phasePrompt = getPhasePrompt(state);
   if (phasePrompt) parts.push(phasePrompt);
 
-  // Staleness warning
   if (isTestRunStale(state)) {
     parts.push(getStaleTestWarning());
   }
 
-  // Ordering warning
   const orderingWarning = getFileOrderingWarning(state, config.ordering_enforcement);
   if (orderingWarning) parts.push(orderingWarning);
 
@@ -72,7 +59,6 @@ function getFileOrderingWarning(
   if (enforcement === "off") return null;
   if (state.phase !== "red") return null;
 
-  // Warn if impl files were edited before any test files
   if (state.impl_files.length > 0 && state.test_files.length === 0) {
     return getOrderingWarning(enforcement);
   }

--- a/packages/pi-red-green/src/tdd-injector.ts
+++ b/packages/pi-red-green/src/tdd-injector.ts
@@ -1,0 +1,101 @@
+import type { TddState, TddConfig, EnforcementLevel } from "./types.js";
+import { getRedPhasePrompt } from "./prompts/red-phase.js";
+import { getGreenPhasePrompt } from "./prompts/green-phase.js";
+import { getRefactorPhasePrompt } from "./prompts/refactor-phase.js";
+import { getNudgePrompt } from "./prompts/nudge.js";
+import { getStaleTestWarning, getOrderingWarning } from "./prompts/warnings.js";
+
+export function buildTddInjectionBlock(
+  state: TddState,
+  config: TddConfig,
+): string | null {
+  if (config.injection_mode === "off") return null;
+
+  // In active-only mode, only inject when TDD is active (non-idle)
+  if (config.injection_mode === "active-only" && state.phase === "idle") {
+    return null;
+  }
+
+  // In nudge mode with idle state, inject gentle reminder
+  if (config.injection_mode === "nudge" && state.phase === "idle") {
+    return `\n\n${getNudgePrompt()}`;
+  }
+
+  // In always mode with idle state, inject nudge
+  if (config.injection_mode === "always" && state.phase === "idle") {
+    return `\n\n${getNudgePrompt()}`;
+  }
+
+  const parts: string[] = [];
+
+  // Phase-specific prompt
+  const phasePrompt = getPhasePrompt(state);
+  if (phasePrompt) parts.push(phasePrompt);
+
+  // Staleness warning
+  if (isTestRunStale(state)) {
+    parts.push(getStaleTestWarning());
+  }
+
+  // Ordering warning
+  const orderingWarning = getFileOrderingWarning(state, config.ordering_enforcement);
+  if (orderingWarning) parts.push(orderingWarning);
+
+  if (parts.length === 0) return null;
+  return "\n\n" + parts.join("\n\n");
+}
+
+function getPhasePrompt(state: TddState): string | null {
+  switch (state.phase) {
+    case "red":
+      return getRedPhasePrompt(state.task);
+    case "green":
+      return getGreenPhasePrompt(state.task, state.last_test_run?.failed ?? 0);
+    case "refactor":
+      return getRefactorPhasePrompt(state.task);
+    case "complete":
+      return null;
+    case "idle":
+      return null;
+  }
+}
+
+export function isTestRunStale(state: TddState): boolean {
+  if (!state.last_test_run) return false;
+  return state.last_test_run.turn_index < state.current_turn_index;
+}
+
+function getFileOrderingWarning(
+  state: TddState,
+  enforcement: EnforcementLevel,
+): string | null {
+  if (enforcement === "off") return null;
+  if (state.phase !== "red") return null;
+
+  // Warn if impl files were edited before any test files
+  if (state.impl_files.length > 0 && state.test_files.length === 0) {
+    return getOrderingWarning(enforcement);
+  }
+
+  return null;
+}
+
+export interface BeforeAgentStartEvent {
+  type: "before_agent_start";
+  prompt: string;
+  systemPrompt: string;
+}
+
+export interface InjectionResult {
+  systemPrompt: string;
+}
+
+export function handleBeforeAgentStart(
+  event: BeforeAgentStartEvent,
+  state: TddState,
+  config: TddConfig,
+): InjectionResult | undefined {
+  const block = buildTddInjectionBlock(state, config);
+  if (!block) return undefined;
+  return { systemPrompt: event.systemPrompt + block };
+}

--- a/packages/pi-red-green/src/tdd-status-command.test.ts
+++ b/packages/pi-red-green/src/tdd-status-command.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { handleTddStatusCommand } from "./tdd-status-command.js";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import type { TddState, TddConfig } from "./types.js";
+import { DEFAULT_CONFIG } from "./config.js";
+import type { StateRef } from "./tdd-command.js";
+
+function makeMockCtx(): ExtensionCommandContext {
+  return {
+    ui: {
+      notify: vi.fn(),
+    },
+    cwd: "/tmp",
+  } as unknown as ExtensionCommandContext;
+}
+
+function makeStateRef(initial: TddState | null = null): StateRef {
+  return {
+    get: () => initial,
+    set: vi.fn(),
+    getConfig: (): TddConfig | null => DEFAULT_CONFIG,
+  };
+}
+
+describe("handleTddStatusCommand", () => {
+  it("shows not-active message when idle", async () => {
+    const ctx = makeMockCtx();
+    await handleTddStatusCommand("", ctx, makeStateRef(createIdleState("s1", "p1")));
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("not active"),
+      "info",
+    );
+  });
+
+  it("shows phase and task for active TDD", async () => {
+    const ctx = makeMockCtx();
+    const state = createInitialState("Add auth", "s1", "p1");
+    await handleTddStatusCommand("", ctx, makeStateRef(state));
+    const output = vi.mocked(ctx.ui.notify).mock.calls[0]?.[0] as string;
+    expect(output).toContain("RED");
+    expect(output).toContain("Add auth");
+  });
+
+  it("shows test run results when available", async () => {
+    const ctx = makeMockCtx();
+    const state: TddState = {
+      ...createInitialState("Add auth", "s1", "p1"),
+      last_test_run: {
+        timestamp: "2026-01-01T00:00:00Z",
+        turn_index: 2,
+        passed: 3,
+        failed: 1,
+        errors: 0,
+        exit_code: 1,
+      },
+    };
+    await handleTddStatusCommand("", ctx, makeStateRef(state));
+    const output = vi.mocked(ctx.ui.notify).mock.calls[0]?.[0] as string;
+    expect(output).toContain("Passed: 3");
+    expect(output).toContain("Failed: 1");
+  });
+
+  it("shows STALE indicator for stale test runs", async () => {
+    const ctx = makeMockCtx();
+    const state: TddState = {
+      ...createInitialState("Add auth", "s1", "p1"),
+      current_turn_index: 5,
+      last_test_run: {
+        timestamp: "2026-01-01T00:00:00Z",
+        turn_index: 2,
+        passed: 3,
+        failed: 0,
+        errors: 0,
+        exit_code: 0,
+      },
+    };
+    await handleTddStatusCommand("", ctx, makeStateRef(state));
+    const output = vi.mocked(ctx.ui.notify).mock.calls[0]?.[0] as string;
+    expect(output).toContain("STALE");
+  });
+
+  it("shows file lists", async () => {
+    const ctx = makeMockCtx();
+    const state: TddState = {
+      ...createInitialState("Add auth", "s1", "p1"),
+      test_files: ["auth.test.ts"],
+      impl_files: ["auth.ts"],
+    };
+    await handleTddStatusCommand("", ctx, makeStateRef(state));
+    const output = vi.mocked(ctx.ui.notify).mock.calls[0]?.[0] as string;
+    expect(output).toContain("auth.test.ts");
+    expect(output).toContain("auth.ts");
+  });
+
+  it("shows phase history", async () => {
+    const ctx = makeMockCtx();
+    const state: TddState = {
+      ...createInitialState("Add auth", "s1", "p1"),
+      phase_history: [
+        { phase: "red", entered_at: "2026-01-01T00:00:00Z" },
+        { phase: "green", entered_at: "2026-01-01T00:10:00Z" },
+      ],
+    };
+    await handleTddStatusCommand("", ctx, makeStateRef(state));
+    const output = vi.mocked(ctx.ui.notify).mock.calls[0]?.[0] as string;
+    expect(output).toContain("Phase history");
+    expect(output).toContain("RED");
+    expect(output).toContain("GREEN");
+  });
+});

--- a/packages/pi-red-green/src/tdd-status-command.ts
+++ b/packages/pi-red-green/src/tdd-status-command.ts
@@ -1,0 +1,52 @@
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { StateRef } from "./tdd-command.js";
+import { isTestRunStale } from "./tdd-injector.js";
+
+export const COMMAND_NAME = "tdd-status";
+
+export async function handleTddStatusCommand(
+  _args: string,
+  ctx: ExtensionCommandContext,
+  stateRef: StateRef,
+): Promise<void> {
+  const state = stateRef.get();
+
+  if (!state || state.phase === "idle") {
+    ctx.ui.notify("TDD is not active. Use /tdd <task description> to start.", "info");
+    return;
+  }
+
+  const lines: string[] = [
+    `## TDD Status`,
+    `**Phase:** ${state.phase.toUpperCase()}`,
+    `**Task:** ${state.task}`,
+    `**Started:** ${state.started_at}`,
+    `**Turn:** ${state.current_turn_index}`,
+    "",
+    `**Test files:** ${state.test_files.length > 0 ? state.test_files.join(", ") : "(none)"}`,
+    `**Impl files:** ${state.impl_files.length > 0 ? state.impl_files.join(", ") : "(none)"}`,
+  ];
+
+  if (state.last_test_run) {
+    const run = state.last_test_run;
+    const stale = isTestRunStale(state);
+    lines.push(
+      "",
+      `**Last test run:**`,
+      `  Passed: ${run.passed}, Failed: ${run.failed}, Errors: ${run.errors}`,
+      `  Exit code: ${run.exit_code}`,
+      `  Turn: ${run.turn_index}${stale ? " (STALE)" : ""}`,
+    );
+  } else {
+    lines.push("", "**Last test run:** (none)");
+  }
+
+  if (state.phase_history.length > 0) {
+    lines.push("", "**Phase history:**");
+    for (const entry of state.phase_history) {
+      lines.push(`  ${entry.phase.toUpperCase()} at ${entry.entered_at}`);
+    }
+  }
+
+  ctx.ui.notify(lines.join("\n"), "info");
+}

--- a/packages/pi-red-green/src/tdd-tools.test.ts
+++ b/packages/pi-red-green/src/tdd-tools.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerTddTools } from "./tdd-tools.js";
+import { createInitialState, createIdleState } from "./state-machine.js";
+import { ensureStorageLayout } from "./storage.js";
+import type { TddState, TddConfig } from "./types.js";
+import { DEFAULT_CONFIG } from "./config.js";
+import type { StateRef } from "./tdd-command.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "rg-tools-test-"));
+
+beforeAll(() => {
+  ensureStorageLayout();
+});
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeStateRef(initial: TddState | null = null): StateRef & { current: TddState | null } {
+  const ref = {
+    current: initial,
+    get: () => ref.current,
+    set: (s: TddState) => {
+      ref.current = s;
+    },
+    getConfig: (): TddConfig | null => DEFAULT_CONFIG,
+  };
+  return ref;
+}
+
+type ToolDef = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: unknown,
+  ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+};
+
+function registerAndCapture(stateRef: StateRef): Map<string, ToolDef> {
+  const tools = new Map<string, ToolDef>();
+  const mockPi = {
+    registerTool: vi.fn((def: ToolDef) => {
+      tools.set(def.name, def);
+    }),
+  } as unknown as ExtensionAPI;
+  registerTddTools(mockPi, stateRef);
+  return tools;
+}
+
+describe("tdd_status tool", () => {
+  it("returns idle message when no active session", async () => {
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_status")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("not active");
+  });
+
+  it("returns phase and task for active session", async () => {
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_status")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("red");
+    expect(result.content[0]?.text).toContain("Add auth");
+  });
+});
+
+describe("tdd_advance tool", () => {
+  beforeEach(() => {
+    ensureStorageLayout(tmpBase);
+  });
+
+  it("throws when no active session", async () => {
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_advance")!;
+    await expect(tool.execute("c1", {}, undefined, null, null)).rejects.toThrow(
+      "No active TDD session",
+    );
+  });
+
+  it("advances from red to green", async () => {
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_advance")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("GREEN");
+    expect(ref.current?.phase).toBe("green");
+  });
+
+  it("advances from green to refactor", async () => {
+    const state: TddState = { ...createInitialState("task", "s1", "p1"), phase: "green" };
+    const ref = makeStateRef(state);
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_advance")!;
+    await tool.execute("c1", {}, undefined, null, null);
+    expect(ref.current?.phase).toBe("refactor");
+  });
+
+  it("warns when already complete", async () => {
+    const state: TddState = { ...createInitialState("task", "s1", "p1"), phase: "complete" };
+    const ref = makeStateRef(state);
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_advance")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("already complete");
+    expect(ref.current?.phase).toBe("complete");
+  });
+});
+
+describe("tdd_reset tool", () => {
+  beforeEach(() => {
+    ensureStorageLayout(tmpBase);
+  });
+
+  it("returns idle message when already idle", async () => {
+    const ref = makeStateRef(createIdleState("s1", "p1"));
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_reset")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("already idle");
+  });
+
+  it("resets active session to idle", async () => {
+    const state = createInitialState("Add auth", "s1", "p1");
+    const ref = makeStateRef(state);
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("tdd_reset")!;
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("reset to idle");
+    expect(ref.current?.phase).toBe("idle");
+  });
+});
+
+describe("registerTddTools", () => {
+  it("registers 3 tools", () => {
+    const ref = makeStateRef();
+    const mockPi = {
+      registerTool: vi.fn(),
+    } as unknown as ExtensionAPI;
+    registerTddTools(mockPi, ref);
+    expect(vi.mocked(mockPi.registerTool)).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/pi-red-green/src/tdd-tools.ts
+++ b/packages/pi-red-green/src/tdd-tools.ts
@@ -1,0 +1,166 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import type { StateRef } from "./tdd-command.js";
+import { advancePhase, createIdleState } from "./state-machine.js";
+import { saveState, clearState, appendCycleRecord } from "./storage.js";
+import { isTestRunStale } from "./tdd-injector.js";
+import type { TddCycleRecord } from "./types.js";
+
+const StatusParams = Type.Object({});
+
+const AdvanceParams = Type.Object({
+  reason: Type.Optional(
+    Type.String({ description: "Why you are manually advancing the phase" }),
+  ),
+});
+
+const ResetParams = Type.Object({
+  reason: Type.Optional(
+    Type.String({ description: "Why you are resetting the TDD state" }),
+  ),
+});
+
+function createStatusTool(stateRef: StateRef) {
+  return {
+    name: "tdd_status" as const,
+    label: "TDD Status",
+    description: "Returns the current TDD phase, task, file history, test results, and staleness",
+    promptSnippet: "Check the current TDD state and phase",
+    parameters: StatusParams,
+    async execute(
+      _toolCallId: string,
+      _params: Record<string, never>,
+      _signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const state = stateRef.get();
+      if (!state || state.phase === "idle") {
+        return {
+          content: [{ type: "text" as const, text: "TDD is not active." }],
+          details: { phase: "idle" },
+        };
+      }
+
+      const stale = isTestRunStale(state);
+      const summary = [
+        `Phase: ${state.phase}`,
+        `Task: ${state.task}`,
+        `Test files: ${state.test_files.join(", ") || "(none)"}`,
+        `Impl files: ${state.impl_files.join(", ") || "(none)"}`,
+        state.last_test_run
+          ? `Last run: ${state.last_test_run.passed} passed, ${state.last_test_run.failed} failed, ${state.last_test_run.errors} errors${stale ? " (STALE)" : ""}`
+          : "Last run: (none)",
+      ].join("\n");
+
+      return {
+        content: [{ type: "text" as const, text: summary }],
+        details: { ...state, is_stale: stale },
+      };
+    },
+  };
+}
+
+function createAdvanceTool(stateRef: StateRef) {
+  return {
+    name: "tdd_advance" as const,
+    label: "TDD Advance",
+    description: "Manually advance to the next TDD phase (escape hatch when auto-detection misses)",
+    promptSnippet: "Manually advance the TDD phase when auto-detection doesn't trigger",
+    parameters: AdvanceParams,
+    async execute(
+      _toolCallId: string,
+      _params: { reason?: string },
+      _signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const state = stateRef.get();
+      if (!state || state.phase === "idle") {
+        throw new Error("No active TDD session. Use /tdd to start one.");
+      }
+
+      const result = advancePhase(state, "manual_advance");
+      stateRef.set(result.state);
+      saveState(result.state);
+
+      const text = result.warning
+        ? result.warning
+        : `Advanced to ${result.state.phase.toUpperCase()}`;
+
+      return {
+        content: [{ type: "text" as const, text }],
+        details: { phase: result.state.phase, warning: result.warning },
+      };
+    },
+  };
+}
+
+function createResetTool(stateRef: StateRef) {
+  return {
+    name: "tdd_reset" as const,
+    label: "TDD Reset",
+    description: "Reset TDD state to idle, optionally recording the partial cycle",
+    promptSnippet: "Reset the TDD session to idle state",
+    parameters: ResetParams,
+    async execute(
+      _toolCallId: string,
+      _params: { reason?: string },
+      _signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const state = stateRef.get();
+      if (!state || state.phase === "idle") {
+        return {
+          content: [{ type: "text" as const, text: "TDD is already idle." }],
+          details: { phase: "idle" },
+        };
+      }
+
+      const record: TddCycleRecord = {
+        task: state.task,
+        session_id: state.session_id,
+        project_id: state.project_id,
+        started_at: state.started_at,
+        completed_at: new Date().toISOString(),
+        final_phase: state.phase,
+        test_files: state.test_files,
+        impl_files: state.impl_files,
+        phase_history: state.phase_history,
+      };
+      appendCycleRecord(record);
+
+      const idleState = createIdleState(state.session_id, state.project_id);
+      stateRef.set(idleState);
+      clearState();
+
+      return {
+        content: [{ type: "text" as const, text: "TDD reset to idle." }],
+        details: { phase: "idle" as string },
+      };
+    },
+  };
+}
+
+export function registerTddTools(
+  pi: ExtensionAPI,
+  stateRef: StateRef,
+): void {
+  const guidelines = [
+    "Use TDD tools to check, advance, or reset the current TDD session state.",
+  ];
+
+  pi.registerTool({
+    ...createStatusTool(stateRef),
+    promptGuidelines: guidelines,
+  });
+  pi.registerTool({
+    ...createAdvanceTool(stateRef),
+    promptGuidelines: guidelines,
+  });
+  pi.registerTool({
+    ...createResetTool(stateRef),
+    promptGuidelines: guidelines,
+  });
+}

--- a/packages/pi-red-green/src/tdd-tools.ts
+++ b/packages/pi-red-green/src/tdd-tools.ts
@@ -1,10 +1,9 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import type { StateRef } from "./tdd-command.js";
+import { type StateRef, recordCycle } from "./tdd-command.js";
 import { advancePhase, createIdleState } from "./state-machine.js";
-import { saveState, clearState, appendCycleRecord } from "./storage.js";
+import { saveState, clearState } from "./storage.js";
 import { isTestRunStale } from "./tdd-injector.js";
-import type { TddCycleRecord } from "./types.js";
 
 const StatusParams = Type.Object({});
 
@@ -118,18 +117,7 @@ function createResetTool(stateRef: StateRef) {
         };
       }
 
-      const record: TddCycleRecord = {
-        task: state.task,
-        session_id: state.session_id,
-        project_id: state.project_id,
-        started_at: state.started_at,
-        completed_at: new Date().toISOString(),
-        final_phase: state.phase,
-        test_files: state.test_files,
-        impl_files: state.impl_files,
-        phase_history: state.phase_history,
-      };
-      appendCycleRecord(record);
+      recordCycle(state);
 
       const idleState = createIdleState(state.session_id, state.project_id);
       stateRef.set(idleState);

--- a/packages/pi-red-green/src/test-run-detector.test.ts
+++ b/packages/pi-red-green/src/test-run-detector.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { isTestRunCommand, parseTestRunResult } from "./test-run-detector.js";
+import { DEFAULT_CONFIG } from "./config.js";
+
+describe("isTestRunCommand", () => {
+  const config = DEFAULT_CONFIG;
+
+  it("detects vitest commands", () => {
+    expect(isTestRunCommand("vitest run", config)).toBe(true);
+    expect(isTestRunCommand("npx vitest", config)).toBe(true);
+    expect(isTestRunCommand("npx vitest run src/foo.test.ts", config)).toBe(true);
+  });
+
+  it("detects jest commands", () => {
+    expect(isTestRunCommand("jest", config)).toBe(true);
+    expect(isTestRunCommand("npx jest --watch", config)).toBe(true);
+  });
+
+  it("detects pytest commands", () => {
+    expect(isTestRunCommand("pytest tests/", config)).toBe(true);
+    expect(isTestRunCommand("python -m pytest", config)).toBe(true);
+  });
+
+  it("detects go test commands", () => {
+    expect(isTestRunCommand("go test ./...", config)).toBe(true);
+  });
+
+  it("detects cargo test commands", () => {
+    expect(isTestRunCommand("cargo test", config)).toBe(true);
+  });
+
+  it("detects npm test", () => {
+    expect(isTestRunCommand("npm test", config)).toBe(true);
+    expect(isTestRunCommand("npm run test", config)).toBe(true);
+  });
+
+  it("returns false for non-test commands", () => {
+    expect(isTestRunCommand("git status", config)).toBe(false);
+    expect(isTestRunCommand("npm install", config)).toBe(false);
+    expect(isTestRunCommand("tsc --noEmit", config)).toBe(false);
+  });
+});
+
+describe("parseTestRunResult", () => {
+  describe("vitest output", () => {
+    it("parses all-passing vitest output", () => {
+      const stdout = `
+ ✓ src/auth.test.ts (5 tests) 3ms
+ ✓ src/utils.test.ts (3 tests) 2ms
+
+ Test Files  2 passed (2)
+      Tests  8 passed (8)
+   Start at  12:00:00
+   Duration  300ms
+`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(8);
+      expect(result!.failed).toBe(0);
+      expect(result!.errors).toBe(0);
+      expect(result!.exit_code).toBe(0);
+    });
+
+    it("parses mixed vitest output", () => {
+      const stdout = `
+ ✓ src/auth.test.ts (3 tests) 3ms
+ × src/utils.test.ts (2 tests | 1 failed) 5ms
+
+ Test Files  1 failed | 1 passed (2)
+      Tests  1 failed | 4 passed (5)
+   Duration  300ms
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(4);
+      expect(result!.failed).toBe(1);
+    });
+
+    it("detects vitest compile errors", () => {
+      const stderr = `
+Error: Cannot find module './nonexistent.js'
+vitest v3.2.4
+`;
+      const result = parseTestRunResult("", stderr, 1);
+      expect(result).not.toBeNull();
+      expect(result!.errors).toBeGreaterThan(0);
+      expect(result!.exit_code).toBe(1);
+    });
+  });
+
+  describe("jest output", () => {
+    it("parses passing jest output", () => {
+      const stdout = `
+Test Suites: 2 passed, 2 total
+Tests:       5 passed, 5 total
+`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(5);
+      expect(result!.failed).toBe(0);
+    });
+
+    it("parses failing jest output", () => {
+      const stdout = `
+Test Suites: 1 failed, 1 passed, 2 total
+Tests:       2 failed, 3 passed, 5 total
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(3);
+      expect(result!.failed).toBe(2);
+    });
+  });
+
+  describe("pytest output", () => {
+    it("parses passing pytest output", () => {
+      const stdout = `
+========================= 5 passed in 0.3s =========================
+`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(5);
+      expect(result!.failed).toBe(0);
+    });
+
+    it("parses mixed pytest output", () => {
+      const stdout = `
+========================= 2 failed, 3 passed in 0.5s =========================
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(3);
+      expect(result!.failed).toBe(2);
+    });
+
+    it("parses pytest with errors", () => {
+      const stdout = `
+========================= 1 error in 0.2s =========================
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.errors).toBe(1);
+    });
+  });
+
+  describe("go test output", () => {
+    it("parses passing go test output", () => {
+      const stdout = `
+--- PASS: TestAdd (0.00s)
+--- PASS: TestSub (0.00s)
+ok  	mypackage	0.005s
+`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(2);
+      expect(result!.failed).toBe(0);
+    });
+
+    it("parses failing go test output", () => {
+      const stdout = `
+--- PASS: TestAdd (0.00s)
+--- FAIL: TestSub (0.00s)
+FAIL	mypackage	0.005s
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(1);
+      expect(result!.failed).toBe(1);
+    });
+
+    it("parses go test with only summary line", () => {
+      const stdout = `ok  	mypackage	0.005s\n`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBeGreaterThan(0);
+    });
+  });
+
+  describe("cargo test output", () => {
+    it("parses passing cargo test output", () => {
+      const stdout = `
+running 3 tests
+test tests::test_add ... ok
+test tests::test_sub ... ok
+test tests::test_mul ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+`;
+      const result = parseTestRunResult(stdout, "", 0);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(3);
+      expect(result!.failed).toBe(0);
+    });
+
+    it("parses failing cargo test output", () => {
+      const stdout = `
+running 3 tests
+test tests::test_add ... ok
+test tests::test_sub ... FAILED
+test tests::test_mul ... ok
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+`;
+      const result = parseTestRunResult(stdout, "", 1);
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(2);
+      expect(result!.failed).toBe(1);
+    });
+  });
+
+  describe("unrecognized output", () => {
+    it("returns null for non-test output", () => {
+      const result = parseTestRunResult("hello world", "", 0);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/pi-red-green/src/test-run-detector.ts
+++ b/packages/pi-red-green/src/test-run-detector.ts
@@ -1,12 +1,24 @@
 import type { TddConfig, TestRunResult } from "./types.js";
 
+let cachedLowerPatterns: readonly string[] | null = null;
+let cachedPatternSource: readonly string[] | null = null;
+
+function getLowerPatterns(patterns: readonly string[]): readonly string[] {
+  if (cachedPatternSource === patterns && cachedLowerPatterns) {
+    return cachedLowerPatterns;
+  }
+  cachedLowerPatterns = patterns.map((p) => p.toLowerCase());
+  cachedPatternSource = patterns;
+  return cachedLowerPatterns;
+}
+
 export function isTestRunCommand(
   command: string,
   config: TddConfig,
 ): boolean {
   const normalized = command.trim().toLowerCase();
-  return config.test_runner_patterns.some((pattern) =>
-    normalized.includes(pattern.toLowerCase()),
+  return getLowerPatterns(config.test_runner_patterns).some((pattern) =>
+    normalized.includes(pattern),
   );
 }
 

--- a/packages/pi-red-green/src/test-run-detector.ts
+++ b/packages/pi-red-green/src/test-run-detector.ts
@@ -1,0 +1,223 @@
+import type { TddConfig, TestRunResult } from "./types.js";
+
+export function isTestRunCommand(
+  command: string,
+  config: TddConfig,
+): boolean {
+  const normalized = command.trim().toLowerCase();
+  return config.test_runner_patterns.some((pattern) =>
+    normalized.includes(pattern.toLowerCase()),
+  );
+}
+
+interface RunnerParser {
+  name: string;
+  detect: (stdout: string, stderr: string) => boolean;
+  parse: (stdout: string, stderr: string, exitCode: number) => TestRunResult | null;
+}
+
+const vitestJestParser: RunnerParser = {
+  name: "vitest/jest",
+  detect: (stdout, stderr) => {
+    const combined = stdout + stderr;
+    return /Tests?\s+\d/.test(combined) || /Test Suites?:/.test(combined) || /vitest/i.test(combined);
+  },
+  parse: (stdout, stderr, exitCode) => {
+    const combined = stdout + stderr;
+    let passed = 0;
+    let failed = 0;
+    let errors = 0;
+
+    // Vitest format: "Tests  24 passed (24)" or "Tests  1 failed | 23 passed (24)"
+    const vitestMatch = combined.match(
+      /Tests\s+(?:(\d+)\s+failed\s*\|?\s*)?(\d+)\s+passed/,
+    );
+    if (vitestMatch) {
+      failed = parseInt(vitestMatch[1] ?? "0", 10);
+      passed = parseInt(vitestMatch[2] ?? "0", 10);
+    }
+
+    // Jest format: "Tests:  1 failed, 2 passed, 3 total"
+    const jestMatch = combined.match(
+      /Tests:\s+(?:(\d+)\s+failed,?\s*)?(?:(\d+)\s+passed)?/,
+    );
+    if (!vitestMatch && jestMatch) {
+      failed = parseInt(jestMatch[1] ?? "0", 10);
+      passed = parseInt(jestMatch[2] ?? "0", 10);
+    }
+
+    // Detect errors (compile/runtime errors before tests run)
+    if (exitCode !== 0 && passed === 0 && failed === 0) {
+      errors = 1;
+    }
+
+    if (passed === 0 && failed === 0 && errors === 0) {
+      return null;
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      turn_index: 0,
+      passed,
+      failed,
+      errors,
+      exit_code: exitCode,
+    };
+  },
+};
+
+const pytestParser: RunnerParser = {
+  name: "pytest",
+  detect: (stdout, stderr) => {
+    const combined = stdout + stderr;
+    return /=+ .*(passed|failed|error).* =+/.test(combined) || /pytest/.test(combined);
+  },
+  parse: (stdout, stderr, exitCode) => {
+    const combined = stdout + stderr;
+    let passed = 0;
+    let failed = 0;
+    let errors = 0;
+
+    // pytest format: "3 passed, 1 failed, 2 errors"
+    const passedMatch = combined.match(/(\d+)\s+passed/);
+    const failedMatch = combined.match(/(\d+)\s+failed/);
+    const errorsMatch = combined.match(/(\d+)\s+error/);
+
+    if (passedMatch) passed = parseInt(passedMatch[1]!, 10);
+    if (failedMatch) failed = parseInt(failedMatch[1]!, 10);
+    if (errorsMatch) errors = parseInt(errorsMatch[1]!, 10);
+
+    if (exitCode !== 0 && passed === 0 && failed === 0 && errors === 0) {
+      errors = 1;
+    }
+
+    if (passed === 0 && failed === 0 && errors === 0) {
+      return null;
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      turn_index: 0,
+      passed,
+      failed,
+      errors,
+      exit_code: exitCode,
+    };
+  },
+};
+
+const goTestParser: RunnerParser = {
+  name: "go test",
+  detect: (stdout, stderr) => {
+    const combined = stdout + stderr;
+    return /^(ok|FAIL)\s+\S+/.test(combined) || /--- (PASS|FAIL):/.test(combined);
+  },
+  parse: (stdout, stderr, exitCode) => {
+    const combined = stdout + stderr;
+    let passed = 0;
+    let failed = 0;
+    let errors = 0;
+
+    const passMatches = combined.match(/--- PASS:/g);
+    const failMatches = combined.match(/--- FAIL:/g);
+    if (passMatches) passed = passMatches.length;
+    if (failMatches) failed = failMatches.length;
+
+    // Detect panics or build errors
+    if (/panic:/.test(combined) || /build failed/.test(combined.toLowerCase())) {
+      errors = 1;
+    }
+
+    if (exitCode !== 0 && passed === 0 && failed === 0 && errors === 0) {
+      errors = 1;
+    }
+
+    if (passed === 0 && failed === 0 && errors === 0) {
+      // Check for "ok" lines without individual test output
+      if (/^ok\s/m.test(combined) && exitCode === 0) {
+        passed = 1;
+      } else if (/^FAIL\s/m.test(combined)) {
+        failed = 1;
+      }
+    }
+
+    if (passed === 0 && failed === 0 && errors === 0) {
+      return null;
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      turn_index: 0,
+      passed,
+      failed,
+      errors,
+      exit_code: exitCode,
+    };
+  },
+};
+
+const cargoTestParser: RunnerParser = {
+  name: "cargo test",
+  detect: (stdout, stderr) => {
+    const combined = stdout + stderr;
+    return /test result:/.test(combined);
+  },
+  parse: (stdout, stderr, exitCode) => {
+    const combined = stdout + stderr;
+    let passed = 0;
+    let failed = 0;
+    let errors = 0;
+
+    // cargo test format: "test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out"
+    const resultMatch = combined.match(
+      /test result: \w+\.\s+(\d+)\s+passed;\s+(\d+)\s+failed/,
+    );
+    if (resultMatch) {
+      passed = parseInt(resultMatch[1]!, 10);
+      failed = parseInt(resultMatch[2]!, 10);
+    }
+
+    if (/error\[E\d+\]/.test(combined)) {
+      errors = 1;
+    }
+
+    if (exitCode !== 0 && passed === 0 && failed === 0 && errors === 0) {
+      errors = 1;
+    }
+
+    if (passed === 0 && failed === 0 && errors === 0) {
+      return null;
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      turn_index: 0,
+      passed,
+      failed,
+      errors,
+      exit_code: exitCode,
+    };
+  },
+};
+
+const PARSERS: readonly RunnerParser[] = [
+  vitestJestParser,
+  pytestParser,
+  goTestParser,
+  cargoTestParser,
+];
+
+export function parseTestRunResult(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): TestRunResult | null {
+  for (const parser of PARSERS) {
+    if (parser.detect(stdout, stderr)) {
+      const result = parser.parse(stdout, stderr, exitCode);
+      if (result) return result;
+    }
+  }
+
+  return null;
+}

--- a/packages/pi-red-green/src/types.ts
+++ b/packages/pi-red-green/src/types.ts
@@ -1,0 +1,75 @@
+export type TddPhase = "idle" | "red" | "green" | "refactor" | "complete";
+
+export type InjectionMode = "always" | "active-only" | "nudge" | "off";
+
+export type EnforcementLevel = "warn" | "strict" | "off";
+
+export type PhaseTransitionTrigger =
+  | "tests_fail"
+  | "tests_error"
+  | "tests_pass"
+  | "manual_advance"
+  | "reset";
+
+export interface TestFilePatterns {
+  readonly typescript: readonly string[];
+  readonly python: readonly string[];
+  readonly go: readonly string[];
+  readonly rust: readonly string[];
+  readonly java: readonly string[];
+  readonly php: readonly string[];
+}
+
+export interface TddConfig {
+  readonly injection_mode: InjectionMode;
+  readonly ordering_enforcement: EnforcementLevel;
+  readonly coverage_threshold: number;
+  readonly coverage_enabled: boolean;
+  readonly auto_advance: boolean;
+  readonly test_file_patterns: TestFilePatterns;
+  readonly test_runner_patterns: readonly string[];
+}
+
+export interface TestRunResult {
+  readonly timestamp: string;
+  readonly turn_index: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly errors: number;
+  readonly exit_code: number;
+}
+
+export interface PhaseHistoryEntry {
+  readonly phase: TddPhase;
+  readonly entered_at: string;
+}
+
+export interface TddState {
+  readonly phase: TddPhase;
+  readonly task: string;
+  readonly started_at: string;
+  readonly session_id: string;
+  readonly project_id: string;
+  readonly test_files: readonly string[];
+  readonly impl_files: readonly string[];
+  readonly last_test_run: TestRunResult | null;
+  readonly phase_history: readonly PhaseHistoryEntry[];
+  readonly current_turn_index: number;
+}
+
+export interface PhaseTransitionResult {
+  readonly state: TddState;
+  readonly warning: string | null;
+}
+
+export interface TddCycleRecord {
+  readonly task: string;
+  readonly session_id: string;
+  readonly project_id: string;
+  readonly started_at: string;
+  readonly completed_at: string;
+  readonly final_phase: TddPhase;
+  readonly test_files: readonly string[];
+  readonly impl_files: readonly string[];
+  readonly phase_history: readonly PhaseHistoryEntry[];
+}

--- a/packages/pi-red-green/tsconfig.build.json
+++ b/packages/pi-red-green/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pi-red-green/tsconfig.json
+++ b/packages/pi-red-green/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/pi-red-green/vitest.config.ts
+++ b/packages/pi-red-green/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      thresholds: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    },
+  },
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
     }
   ],
   "packages": {
-    "packages/pi-continuous-learning": {}
+    "packages/pi-continuous-learning": {},
+    "packages/pi-red-green": {}
   }
 }


### PR DESCRIPTION
## Summary

- New `pi-red-green` extension package: TDD enforcement for Pi coding agent sessions
- Tracks RED-GREEN-REFACTOR state machine with automatic phase advancement
- Injects phase-specific prompts into the agent's system prompt via `before_agent_start`
- Detects test runner output (vitest, jest, pytest, go test, cargo test) and auto-advances phases
- Classifies file edits as test/implementation/other to enforce write-tests-first ordering
- Persistent status bar indicator via `ctx.ui.setStatus()` with graceful fallback
- Slash commands: `/tdd` (activate/deactivate), `/tdd-status` (detailed status)
- LLM tools: `tdd_status`, `tdd_advance`, `tdd_reset`
- 151 tests across 11 test files, 80% coverage thresholds
- Release-please and publish workflow configured for the new package

## Post-merge

After merging, the first npm publish will need to be done manually to configure trusted publishing from this repository. Subsequent releases will go through release-please.

## Test plan

- [x] `npm run check` passes at root (both workspaces)
- [x] `npm run build -w packages/pi-red-green` produces clean dist/
- [x] 151 tests passing, clean lint, clean typecheck
- [ ] Manual test: install in a project, `/tdd "task"`, verify prompt injection
- [ ] First npm publish after merge

Closes #81
