### PR TITLE
fix: use pi install command in README, document convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ packages/
     docs/                   # Package documentation (internals.md, specification.md)
     AGENTS.md               # Package-level conventions, directory structure, testing
     CHANGELOG.md            # Release history (managed by release-please)
+  pi-red-green/             # Pi extension: TDD enforcement (red-green-refactor)
+    src/                    # TypeScript source + tests (*.test.ts alongside source)
+    CHANGELOG.md            # Release history (managed by release-please)
 ```
 
 ## Commands (run from repo root)
@@ -39,6 +42,10 @@ When working inside `packages/pi-continuous-learning`, refer to `packages/pi-con
 - Full directory structure with file descriptions
 - Testing approach
 - Documentation update guidelines
+
+## README conventions
+
+- Installation instructions in package READMEs must use `pi install npm:<package-name>`, not `npm install`. These are Pi extensions installed via the Pi CLI.
 
 ## Adding a new package
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,7 @@ All runtime data lives under `~/.pi/continuous-learning/`:
 - Strict mode with `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` — array access returns `T | undefined`, optional properties cannot be assigned `undefined` explicitly
 - Prefix intentionally unused parameters with `_` (ESLint ignores `^_`)
 - `console.warn` and `console.error` are allowed; `console.log`/`console.info` are not
+
+### README conventions
+
+- Installation instructions in package READMEs must use `pi install npm:<package-name>`, not `npm install`. These are Pi extensions installed via the Pi CLI.

--- a/packages/pi-red-green/README.md
+++ b/packages/pi-red-green/README.md
@@ -5,15 +5,7 @@ TDD enforcement for [Pi coding agent](https://github.com/nicepkg/pi) sessions. F
 ## Installation
 
 ```bash
-npm install pi-red-green
-```
-
-Add to your Pi config:
-
-```json
-{
-  "extensions": ["pi-red-green"]
-}
+pi install npm:pi-red-green
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Fix pi-red-green README: use `pi install npm:pi-red-green` instead of `npm install`
- Add README convention to CLAUDE.md and AGENTS.md so future packages use the correct install command
- Add pi-red-green to AGENTS.md repo structure

## Test plan

- [x] README shows correct install command
- [x] Convention documented in both CLAUDE.md and AGENTS.md
