### PR TITLE
docs: add pi-red-green to root README, enforce update on new packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,4 +55,6 @@ When working inside `packages/pi-continuous-learning`, refer to `packages/pi-con
 4. Add `{ "path": "packages/<name>" }` to root `tsconfig.json` references
 5. Add `"packages/<name>": {}` to `release-please-config.json`
 6. Add `"packages/<name>": "0.1.0"` to `.release-please-manifest.json`
-7. No changes needed to `eslint.config.js`, `.mega-linter.yml`, `ci.yml`, or `publish.yml`
+7. Add the package to the **Packages** table in the root `README.md`
+8. Add the package to the **Repository structure** section in this file (`AGENTS.md`)
+9. No changes needed to `eslint.config.js`, `.mega-linter.yml`, `ci.yml`, or `publish.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,4 @@ All runtime data lives under `~/.pi/continuous-learning/`:
 ### README conventions
 
 - Installation instructions in package READMEs must use `pi install npm:<package-name>`, not `npm install`. These are Pi extensions installed via the Pi CLI.
+- When adding a new package, add it to the **Packages** table in the root `README.md` and the **Repository structure** in `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A monorepo of [Pi](https://github.com/nicholasgasior/pi-coding-agent) extensions
 | Package | Description | npm |
 |---|---|---|
 | [pi-continuous-learning](packages/pi-continuous-learning) | Observes coding sessions and distils patterns into reusable instincts with confidence scoring and closed-loop feedback | [![npm](https://img.shields.io/npm/v/pi-continuous-learning)](https://www.npmjs.com/package/pi-continuous-learning) |
+| [pi-red-green](packages/pi-red-green) | TDD enforcement for agent sessions: RED-GREEN-REFACTOR state machine with phase-specific prompt injection and test run detection | [![npm](https://img.shields.io/npm/v/pi-red-green)](https://www.npmjs.com/package/pi-red-green) |
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Add pi-red-green to the Packages table in root README.md
- Add steps to the "Adding a new package" checklist in AGENTS.md: update root README and AGENTS.md repo structure
- Add matching convention to CLAUDE.md so future packages follow the same pattern

## Test plan

- [x] Root README lists both packages with npm badges
- [x] AGENTS.md checklist includes README and structure updates (steps 7-8)
- [x] CLAUDE.md documents the convention
