### PR TITLE
feat: add pi-compass codebase navigation extension

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/pi-continuous-learning": "0.13.2",
-  "packages/pi-red-green": "0.2.1"
+  "packages/pi-red-green": "0.2.1",
+  "packages/pi-compass": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ packages/
   pi-red-green/             # Pi extension: TDD enforcement (red-green-refactor)
     src/                    # TypeScript source + tests (*.test.ts alongside source)
     CHANGELOG.md            # Release history (managed by release-please)
+  pi-compass/               # Pi extension: codebase navigation (codemap + code tours)
+    src/                    # TypeScript source + tests (*.test.ts alongside source)
+    CHANGELOG.md            # Release history (managed by release-please)
 ```
 
 ## Commands (run from repo root)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A monorepo of [Pi](https://github.com/nicholasgasior/pi-coding-agent) extensions
 |---|---|---|
 | [pi-continuous-learning](packages/pi-continuous-learning) | Observes coding sessions and distils patterns into reusable instincts with confidence scoring and closed-loop feedback | [![npm](https://img.shields.io/npm/v/pi-continuous-learning)](https://www.npmjs.com/package/pi-continuous-learning) |
 | [pi-red-green](packages/pi-red-green) | TDD enforcement for agent sessions: RED-GREEN-REFACTOR state machine with phase-specific prompt injection and test run detection | [![npm](https://img.shields.io/npm/v/pi-red-green)](https://www.npmjs.com/package/pi-red-green) |
+| [pi-compass](packages/pi-compass) | Codebase navigation: generates structured codemaps and interactive code tours for faster agent onboarding | [![npm](https://img.shields.io/npm/v/pi-compass)](https://www.npmjs.com/package/pi-compass) |
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4023,6 +4023,10 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/pi-compass": {
+      "resolved": "packages/pi-compass",
+      "link": true
+    },
     "node_modules/pi-continuous-learning": {
       "resolved": "packages/pi-continuous-learning",
       "link": true
@@ -4992,6 +4996,27 @@
       "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "packages/pi-compass": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-coding-agent": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.62.0",
+        "@sinclair/typebox": "^0.34.0"
       }
     },
     "packages/pi-continuous-learning": {

--- a/packages/pi-compass/README.md
+++ b/packages/pi-compass/README.md
@@ -1,0 +1,74 @@
+# pi-compass
+
+Codebase navigation for [Pi coding agent](https://github.com/nicholasgasior/pi-coding-agent) sessions. Generates structured codemaps and interactive code tours so agents (and developers) can orient themselves in unfamiliar repos without burning tokens on exploration.
+
+## Installation
+
+```bash
+pi install npm:pi-compass
+```
+
+## Usage
+
+### Generate a codebase map
+
+```
+/onboard
+```
+
+Analyzes the current repo and generates a structured map covering:
+- Directory structure
+- Package managers and dependencies
+- Detected frameworks
+- Entry points
+- Build, test, and deploy scripts
+- Coding conventions (from AGENTS.md, CLAUDE.md, lint configs, etc.)
+- Key files (README, LICENSE, CI configs, etc.)
+
+The map is cached and automatically injected into the agent's system prompt on the first turn of each session.
+
+### Force regeneration
+
+```
+/onboard --refresh
+```
+
+### Take a code tour
+
+```
+/tour              # list available topics
+/tour auth         # guided walkthrough of the auth module
+/tour testing      # walkthrough of test infrastructure
+/tour ci           # walkthrough of CI/CD configuration
+```
+
+Topics are detected automatically from directory structure and project configuration.
+
+## LLM Tools
+
+| Tool | Description |
+|------|-------------|
+| `codebase_map` | Returns the cached codemap (generates if missing) |
+| `code_tour` | Returns a guided walkthrough for a topic, or lists available topics |
+
+## How it works
+
+All analysis is deterministic (no LLM calls). The extension reads config files, directory listings, and package manifests to build a structured overview. Results are cached per project with content-hash invalidation: the cache is marked stale when key config files or the directory structure changes.
+
+### Cache invalidation
+
+The content hash covers: package.json, tsconfig.json, go.mod, Cargo.toml, pyproject.toml, and the top-level directory listing. When any of these change, the cached codemap is marked stale. Stale maps are still served (better than nothing) with a note to run `/onboard` to refresh.
+
+## Storage
+
+```
+~/.pi/compass/
+  projects/<project-hash>/
+    codemap.json        # Cached codemap
+    tours/
+      <topic>.json      # Cached tours
+```
+
+## License
+
+MIT

--- a/packages/pi-compass/package.json
+++ b/packages/pi-compass/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "pi-compass",
+  "version": "0.1.0",
+  "description": "A Pi extension that generates structured codebase maps and interactive code tours for agent onboarding.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Matt Devy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MattDevy/pi-extensions.git",
+    "directory": "packages/pi-compass"
+  },
+  "homepage": "https://github.com/MattDevy/pi-extensions/tree/main/packages/pi-compass#readme",
+  "bugs": {
+    "url": "https://github.com/MattDevy/pi-extensions/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "codebase-onboarding",
+    "codemap",
+    "code-tour",
+    "ai",
+    "llm",
+    "ai-agent",
+    "coding-assistant",
+    "developer-tools"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**/*.test.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "scripts": {
+    "clean": "rm -rf dist tsconfig.build.tsbuildinfo",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "check": "vitest run && eslint src/ && tsc --noEmit",
+    "prepublishOnly": "npm run build && npm run check",
+    "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.62.0",
+    "@mariozechner/pi-ai": "^0.62.0",
+    "@mariozechner/pi-tui": "^0.62.0",
+    "@sinclair/typebox": "^0.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/pi-compass/src/analyzers/build-script-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/build-script-detector.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectBuildScripts } from "./build-script-detector.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-build-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeDir(name: string): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("detectBuildScripts", () => {
+  it("extracts npm scripts from package.json", () => {
+    const dir = makeDir("npm-scripts");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({
+      scripts: { build: "tsc", test: "vitest", dev: "next dev", random: "echo hi" },
+    }));
+    const scripts = detectBuildScripts(dir);
+    const names = scripts.map((s) => s.name);
+    expect(names).toContain("build");
+    expect(names).toContain("test");
+    expect(names).toContain("dev");
+    expect(names).not.toContain("random");
+  });
+
+  it("extracts Makefile targets", () => {
+    const dir = makeDir("makefile");
+    writeFileSync(join(dir, "Makefile"), `build:
+\tgo build ./...
+
+test:
+\tgo test ./...
+
+.PHONY: build test
+`);
+    const scripts = detectBuildScripts(dir);
+    expect(scripts.map((s) => s.name)).toContain("build");
+    expect(scripts.map((s) => s.name)).toContain("test");
+  });
+
+  it("detects GitHub Actions", () => {
+    const dir = makeDir("ci-gh");
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    writeFileSync(join(dir, ".github", "workflows", "ci.yml"), "name: CI");
+    const scripts = detectBuildScripts(dir);
+    expect(scripts.find((s) => s.source === ".github/workflows/")).toBeDefined();
+  });
+
+  it("detects Dockerfile", () => {
+    const dir = makeDir("docker");
+    writeFileSync(join(dir, "Dockerfile"), "FROM node:18");
+    const scripts = detectBuildScripts(dir);
+    expect(scripts.find((s) => s.name === "docker")).toBeDefined();
+  });
+
+  it("returns empty for bare directory", () => {
+    const dir = makeDir("bare");
+    expect(detectBuildScripts(dir)).toEqual([]);
+  });
+});

--- a/packages/pi-compass/src/analyzers/build-script-detector.ts
+++ b/packages/pi-compass/src/analyzers/build-script-detector.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { BuildScript } from "../types.js";
+
+const INTERESTING_SCRIPTS = new Set([
+  "build", "dev", "start", "test", "lint", "check",
+  "typecheck", "format", "deploy", "clean", "serve",
+  "preview", "generate", "migrate", "seed",
+]);
+
+export function detectBuildScripts(cwd: string): readonly BuildScript[] {
+  const results: BuildScript[] = [];
+
+  results.push(...extractNpmScripts(cwd));
+  results.push(...extractMakefileTargets(cwd));
+  results.push(...detectCiFiles(cwd));
+  results.push(...detectContainerFiles(cwd));
+
+  return results;
+}
+
+function extractNpmScripts(cwd: string): BuildScript[] {
+  try {
+    const raw = readFileSync(join(cwd, "package.json"), "utf-8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    const scripts = pkg["scripts"];
+    if (!scripts || typeof scripts !== "object") return [];
+
+    return Object.entries(scripts as Record<string, unknown>)
+      .filter(([name]) => INTERESTING_SCRIPTS.has(name))
+      .map(([name, cmd]) => ({
+        name,
+        command: typeof cmd === "string" ? cmd : String(cmd),
+        source: "package.json",
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function extractMakefileTargets(cwd: string): BuildScript[] {
+  const makefilePath = join(cwd, "Makefile");
+  try {
+    const content = readFileSync(makefilePath, "utf-8");
+    const targets = [...content.matchAll(/^([a-zA-Z_][\w-]*)\s*:/gm)];
+    return targets
+      .filter(([, name]) => name && !name.startsWith("."))
+      .map(([, name]) => ({
+        name: name!,
+        command: `make ${name}`,
+        source: "Makefile",
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function detectCiFiles(cwd: string): BuildScript[] {
+  const results: BuildScript[] = [];
+
+  if (existsSync(join(cwd, ".github", "workflows"))) {
+    results.push({ name: "ci", command: "GitHub Actions", source: ".github/workflows/" });
+  }
+  if (existsSync(join(cwd, ".gitlab-ci.yml"))) {
+    results.push({ name: "ci", command: "GitLab CI", source: ".gitlab-ci.yml" });
+  }
+  if (existsSync(join(cwd, "Jenkinsfile"))) {
+    results.push({ name: "ci", command: "Jenkins", source: "Jenkinsfile" });
+  }
+
+  return results;
+}
+
+function detectContainerFiles(cwd: string): BuildScript[] {
+  const results: BuildScript[] = [];
+
+  if (existsSync(join(cwd, "Dockerfile"))) {
+    results.push({ name: "docker", command: "docker build", source: "Dockerfile" });
+  }
+  if (existsSync(join(cwd, "docker-compose.yml")) || existsSync(join(cwd, "docker-compose.yaml"))) {
+    results.push({ name: "docker-compose", command: "docker compose up", source: "docker-compose.yml" });
+  }
+
+  return results;
+}

--- a/packages/pi-compass/src/analyzers/convention-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/convention-detector.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectConventions } from "./convention-detector.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-conv-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeDir(name: string): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("detectConventions", () => {
+  it("reads AGENTS.md", () => {
+    const dir = makeDir("agents");
+    writeFileSync(join(dir, "AGENTS.md"), "# Conventions\n\nUse TDD.");
+    const convs = detectConventions(dir);
+    expect(convs.find((c) => c.source === "AGENTS.md")).toBeDefined();
+    expect(convs.find((c) => c.source === "AGENTS.md")?.content).toContain("TDD");
+  });
+
+  it("reads CLAUDE.md", () => {
+    const dir = makeDir("claude");
+    writeFileSync(join(dir, "CLAUDE.md"), "# Commands\n\nnpm test");
+    const convs = detectConventions(dir);
+    expect(convs.find((c) => c.source === "CLAUDE.md")).toBeDefined();
+  });
+
+  it("reads .editorconfig", () => {
+    const dir = makeDir("editor");
+    writeFileSync(join(dir, ".editorconfig"), "root = true\n[*]\nindent_style = space");
+    const convs = detectConventions(dir);
+    expect(convs.find((c) => c.source === ".editorconfig")).toBeDefined();
+  });
+
+  it("truncates large files", () => {
+    const dir = makeDir("large");
+    writeFileSync(join(dir, "AGENTS.md"), "x".repeat(5000));
+    const convs = detectConventions(dir);
+    const agents = convs.find((c) => c.source === "AGENTS.md");
+    expect(agents!.content.length).toBeLessThan(5000);
+    expect(agents!.content).toContain("truncated");
+  });
+
+  it("returns empty for no convention files", () => {
+    const dir = makeDir("none");
+    expect(detectConventions(dir)).toEqual([]);
+  });
+});

--- a/packages/pi-compass/src/analyzers/convention-detector.ts
+++ b/packages/pi-compass/src/analyzers/convention-detector.ts
@@ -1,0 +1,52 @@
+import { join } from "node:path";
+import type { Convention } from "../types.js";
+import { readTextFile } from "../fs-utils.js";
+
+const MAX_CONTENT_LENGTH = 2000;
+
+const CONVENTION_FILES: readonly string[] = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "GEMINI.md",
+  ".editorconfig",
+  "eslint.config.js",
+  "eslint.config.ts",
+  "eslint.config.mjs",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.yml",
+  "prettier.config.js",
+  "prettier.config.ts",
+  ".prettierrc",
+  ".prettierrc.json",
+  "biome.json",
+  "biome.jsonc",
+  "rustfmt.toml",
+  ".golangci.yml",
+  ".golangci.yaml",
+  "CONTRIBUTING.md",
+  ".stylelintrc.json",
+  "deno.json",
+  "deno.jsonc",
+];
+
+export function detectConventions(cwd: string): readonly Convention[] {
+  const results: Convention[] = [];
+
+  for (const file of CONVENTION_FILES) {
+    const content = readTextFile(join(cwd, file));
+    if (content !== null) {
+      results.push({
+        source: file,
+        content: truncate(content, MAX_CONTENT_LENGTH),
+      });
+    }
+  }
+
+  return results;
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + "\n... (truncated)";
+}

--- a/packages/pi-compass/src/analyzers/directory-tree.test.ts
+++ b/packages/pi-compass/src/analyzers/directory-tree.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildDirectoryTree, formatDirectoryTree } from "./directory-tree.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-tree-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function setupProject(name: string, structure: Record<string, string | null>): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [path, content] of Object.entries(structure)) {
+    const fullPath = join(dir, path);
+    if (content === null) {
+      mkdirSync(fullPath, { recursive: true });
+    } else {
+      mkdirSync(join(fullPath, ".."), { recursive: true });
+      writeFileSync(fullPath, content);
+    }
+  }
+  return dir;
+}
+
+describe("buildDirectoryTree", () => {
+  it("lists files and directories", () => {
+    const dir = setupProject("basic", {
+      "src/index.ts": "export {}",
+      "package.json": "{}",
+      "README.md": "# test",
+    });
+    const tree = buildDirectoryTree(dir);
+    const names = tree.map((e) => e.name);
+    expect(names).toContain("src");
+    expect(names).toContain("package.json");
+    expect(names).toContain("README.md");
+  });
+
+  it("excludes node_modules and .git", () => {
+    const dir = setupProject("ignored", {
+      "src/index.ts": "",
+      "node_modules/foo/index.js": "",
+      ".git/HEAD": "",
+    });
+    const tree = buildDirectoryTree(dir);
+    const names = tree.map((e) => e.name);
+    expect(names).not.toContain("node_modules");
+    expect(names).not.toContain(".git");
+  });
+
+  it("includes .github directory", () => {
+    const dir = setupProject("github", {
+      ".github/workflows/ci.yml": "name: CI",
+    });
+    const tree = buildDirectoryTree(dir);
+    expect(tree.map((e) => e.name)).toContain(".github");
+  });
+
+  it("respects depth limit", () => {
+    const dir = setupProject("deep", {
+      "a/b/c/d.txt": "deep",
+    });
+    const tree = buildDirectoryTree(dir, 1);
+    const aEntry = tree.find((e) => e.name === "a");
+    expect(aEntry?.children).toBeUndefined();
+  });
+
+  it("includes children at depth 2", () => {
+    const dir = setupProject("depth2", {
+      "src/index.ts": "",
+      "src/utils/helper.ts": "",
+    });
+    const tree = buildDirectoryTree(dir, 2);
+    const src = tree.find((e) => e.name === "src");
+    expect(src?.children).toBeDefined();
+    expect(src!.children!.map((c) => c.name)).toContain("index.ts");
+  });
+});
+
+describe("formatDirectoryTree", () => {
+  it("formats a simple tree", () => {
+    const tree = [
+      { name: "src", type: "dir" as const, children: [{ name: "index.ts", type: "file" as const }] },
+      { name: "package.json", type: "file" as const },
+    ];
+    const output = formatDirectoryTree(tree);
+    expect(output).toContain("src/");
+    expect(output).toContain("index.ts");
+    expect(output).toContain("package.json");
+  });
+});

--- a/packages/pi-compass/src/analyzers/directory-tree.ts
+++ b/packages/pi-compass/src/analyzers/directory-tree.ts
@@ -1,0 +1,65 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { DirectoryEntry } from "../types.js";
+
+const IGNORED_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", ".next", ".nuxt",
+  "__pycache__", ".tox", ".mypy_cache", ".pytest_cache",
+  "target", ".gradle", ".idea", ".vscode",
+  "vendor", "coverage", ".turbo", ".cache",
+]);
+
+export function buildDirectoryTree(cwd: string, depth = 2): readonly DirectoryEntry[] {
+  return scanDir(cwd, cwd, depth);
+}
+
+function scanDir(dir: string, root: string, remaining: number): DirectoryEntry[] {
+  if (remaining <= 0) return [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const result: DirectoryEntry[] = [];
+
+  for (const name of entries.sort()) {
+    if (name.startsWith(".") && name !== ".github") continue;
+    if (IGNORED_DIRS.has(name)) continue;
+
+    const fullPath = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const children = remaining > 1 ? scanDir(fullPath, root, remaining - 1) : undefined;
+      result.push({ name, type: "dir", ...(children ? { children } : {}) });
+    } else if (stat.isFile()) {
+      result.push({ name, type: "file" });
+    }
+  }
+
+  return result;
+}
+
+export function formatDirectoryTree(entries: readonly DirectoryEntry[], indent = ""): string {
+  const lines: string[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!;
+    const isLast = i === entries.length - 1;
+    const prefix = isLast ? "└── " : "├── ";
+    const childIndent = indent + (isLast ? "    " : "│   ");
+
+    lines.push(`${indent}${prefix}${entry.name}${entry.type === "dir" ? "/" : ""}`);
+    if (entry.children && entry.children.length > 0) {
+      lines.push(formatDirectoryTree(entry.children, childIndent));
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/pi-compass/src/analyzers/entry-point-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/entry-point-detector.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectEntryPoints } from "./entry-point-detector.js";
+import type { PackageInfo } from "../types.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-entry-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function setup(name: string, files: string[]): string {
+  const dir = join(tmpBase, name);
+  for (const file of files) {
+    const full = join(dir, file);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, "");
+  }
+  return dir;
+}
+
+const npmPkg: PackageInfo = { manager: "npm", name: "test", dependencies: [] };
+
+describe("detectEntryPoints", () => {
+  it("detects src/index.ts", () => {
+    const dir = setup("ts-index", ["src/index.ts"]);
+    const points = detectEntryPoints(dir, []);
+    expect(points.map((p) => p.path)).toContain("src/index.ts");
+  });
+
+  it("detects main field from package.json", () => {
+    const dir = setup("main-field", ["src/index.ts"]);
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ main: "./dist/index.js" }));
+    const points = detectEntryPoints(dir, [npmPkg]);
+    expect(points.map((p) => p.path)).toContain("./dist/index.js");
+  });
+
+  it("detects route directories", () => {
+    const dir = setup("routes", ["src/routes/api.ts", "src/index.ts"]);
+    const points = detectEntryPoints(dir, []);
+    expect(points.map((p) => p.path)).toContain("src/routes");
+  });
+
+  it("detects config files", () => {
+    const dir = setup("config", ["next.config.js", "src/index.ts"]);
+    const points = detectEntryPoints(dir, []);
+    expect(points.map((p) => p.path)).toContain("next.config.js");
+  });
+
+  it("detects Go entry point", () => {
+    const dir = setup("go", ["main.go"]);
+    const points = detectEntryPoints(dir, []);
+    expect(points.map((p) => p.path)).toContain("main.go");
+  });
+
+  it("detects Python entry point", () => {
+    const dir = setup("py", ["manage.py"]);
+    const points = detectEntryPoints(dir, []);
+    expect(points.map((p) => p.path)).toContain("manage.py");
+  });
+
+  it("returns empty for no matches", () => {
+    const dir = setup("empty", ["docs/readme.txt"]);
+    expect(detectEntryPoints(dir, [])).toEqual([]);
+  });
+});

--- a/packages/pi-compass/src/analyzers/entry-point-detector.ts
+++ b/packages/pi-compass/src/analyzers/entry-point-detector.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PackageInfo, EntryPoint } from "../types.js";
+
+const COMMON_ENTRY_POINTS: readonly { path: string; kind: EntryPoint["kind"] }[] = [
+  { path: "src/index.ts", kind: "index" },
+  { path: "src/index.tsx", kind: "index" },
+  { path: "src/index.js", kind: "index" },
+  { path: "src/main.ts", kind: "main" },
+  { path: "src/main.tsx", kind: "main" },
+  { path: "src/main.js", kind: "main" },
+  { path: "src/app.ts", kind: "main" },
+  { path: "src/app.tsx", kind: "main" },
+  { path: "src/app.js", kind: "main" },
+  { path: "index.ts", kind: "index" },
+  { path: "index.js", kind: "index" },
+  { path: "main.go", kind: "main" },
+  { path: "cmd/main.go", kind: "main" },
+  { path: "src/main.rs", kind: "main" },
+  { path: "src/lib.rs", kind: "main" },
+  { path: "manage.py", kind: "main" },
+  { path: "app.py", kind: "main" },
+  { path: "main.py", kind: "main" },
+];
+
+const ROUTE_DIRS: readonly string[] = [
+  "src/routes",
+  "src/pages",
+  "src/api",
+  "app/routes",
+  "app/api",
+  "pages",
+  "routes",
+  "api",
+];
+
+const CONFIG_FILES: readonly string[] = [
+  "next.config.js",
+  "next.config.ts",
+  "next.config.mjs",
+  "vite.config.ts",
+  "vite.config.js",
+  "webpack.config.js",
+  "webpack.config.ts",
+  "nuxt.config.ts",
+  "astro.config.mjs",
+];
+
+export function detectEntryPoints(
+  cwd: string,
+  packages: readonly PackageInfo[],
+): readonly EntryPoint[] {
+  const results: EntryPoint[] = [];
+  const seen = new Set<string>();
+
+  for (const pkg of packages) {
+    if (pkg.manager === "npm") {
+      const mainField = extractMainField(cwd);
+      if (mainField && !seen.has(mainField)) {
+        seen.add(mainField);
+        results.push({ path: mainField, kind: "main" });
+      }
+    }
+  }
+
+  for (const { path, kind } of COMMON_ENTRY_POINTS) {
+    if (!seen.has(path) && existsSync(join(cwd, path))) {
+      seen.add(path);
+      results.push({ path, kind });
+    }
+  }
+
+  for (const dir of ROUTE_DIRS) {
+    if (existsSync(join(cwd, dir))) {
+      results.push({ path: dir, kind: "route" });
+    }
+  }
+
+  for (const config of CONFIG_FILES) {
+    if (!seen.has(config) && existsSync(join(cwd, config))) {
+      seen.add(config);
+      results.push({ path: config, kind: "config" });
+    }
+  }
+
+  return results;
+}
+
+function extractMainField(cwd: string): string | null {
+  try {
+    const raw = readFileSync(join(cwd, "package.json"), "utf-8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof pkg["main"] === "string") return pkg["main"];
+  } catch {
+    // absent
+  }
+  return null;
+}

--- a/packages/pi-compass/src/analyzers/framework-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/framework-detector.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { detectFrameworks } from "./framework-detector.js";
+import type { PackageInfo } from "../types.js";
+
+function npmPkg(deps: string[]): PackageInfo {
+  return { manager: "npm", name: "test", dependencies: deps };
+}
+
+describe("detectFrameworks", () => {
+  it("detects React from dependencies", () => {
+    const result = detectFrameworks([npmPkg(["react", "react-dom"])]);
+    expect(result).toEqual([
+      expect.objectContaining({ name: "React", confidence: "definite" }),
+    ]);
+  });
+
+  it("detects Next.js", () => {
+    const result = detectFrameworks([npmPkg(["next", "react"])]);
+    expect(result.map((f) => f.name)).toContain("Next.js");
+    expect(result.map((f) => f.name)).toContain("React");
+  });
+
+  it("detects Express", () => {
+    const result = detectFrameworks([npmPkg(["express"])]);
+    expect(result).toEqual([
+      expect.objectContaining({ name: "Express", confidence: "definite" }),
+    ]);
+  });
+
+  it("detects Vitest", () => {
+    const result = detectFrameworks([npmPkg(["vitest"])]);
+    expect(result.map((f) => f.name)).toContain("Vitest");
+  });
+
+  it("detects Python frameworks from pip deps", () => {
+    const pkg: PackageInfo = { manager: "pip", name: "myapp", dependencies: ["django", "celery"] };
+    const result = detectFrameworks([pkg]);
+    expect(result.map((f) => f.name)).toContain("Django");
+  });
+
+  it("detects Rust frameworks from cargo deps", () => {
+    const pkg: PackageInfo = { manager: "cargo", name: "myapp", dependencies: ["actix-web", "tokio"] };
+    const result = detectFrameworks([pkg]);
+    expect(result.map((f) => f.name)).toContain("Actix Web");
+    expect(result.map((f) => f.name)).toContain("Tokio");
+  });
+
+  it("deduplicates frameworks", () => {
+    const result = detectFrameworks([
+      npmPkg(["@nestjs/core", "nestjs"]),
+    ]);
+    const nestCounts = result.filter((f) => f.name === "NestJS");
+    expect(nestCounts).toHaveLength(1);
+  });
+
+  it("returns empty for no matches", () => {
+    expect(detectFrameworks([npmPkg(["lodash"])])).toEqual([]);
+  });
+
+  it("handles multiple package managers", () => {
+    const result = detectFrameworks([
+      npmPkg(["react"]),
+      { manager: "pip", name: "backend", dependencies: ["flask"] },
+    ]);
+    expect(result.map((f) => f.name)).toContain("React");
+    expect(result.map((f) => f.name)).toContain("Flask");
+  });
+});

--- a/packages/pi-compass/src/analyzers/framework-detector.ts
+++ b/packages/pi-compass/src/analyzers/framework-detector.ts
@@ -1,0 +1,76 @@
+import type { PackageInfo, FrameworkDetection } from "../types.js";
+
+interface FrameworkRule {
+  readonly dep: string;
+  readonly name: string;
+  readonly confidence: "definite" | "likely";
+}
+
+const FRAMEWORK_RULES: readonly FrameworkRule[] = [
+  { dep: "next", name: "Next.js", confidence: "definite" },
+  { dep: "react", name: "React", confidence: "definite" },
+  { dep: "vue", name: "Vue", confidence: "definite" },
+  { dep: "@angular/core", name: "Angular", confidence: "definite" },
+  { dep: "svelte", name: "Svelte", confidence: "definite" },
+  { dep: "express", name: "Express", confidence: "definite" },
+  { dep: "fastify", name: "Fastify", confidence: "definite" },
+  { dep: "hono", name: "Hono", confidence: "definite" },
+  { dep: "koa", name: "Koa", confidence: "definite" },
+  { dep: "nestjs", name: "NestJS", confidence: "likely" },
+  { dep: "@nestjs/core", name: "NestJS", confidence: "definite" },
+  { dep: "nuxt", name: "Nuxt", confidence: "definite" },
+  { dep: "remix", name: "Remix", confidence: "likely" },
+  { dep: "@remix-run/react", name: "Remix", confidence: "definite" },
+  { dep: "astro", name: "Astro", confidence: "definite" },
+  { dep: "gatsby", name: "Gatsby", confidence: "definite" },
+  { dep: "tailwindcss", name: "Tailwind CSS", confidence: "definite" },
+  { dep: "prisma", name: "Prisma", confidence: "definite" },
+  { dep: "@prisma/client", name: "Prisma", confidence: "definite" },
+  { dep: "drizzle-orm", name: "Drizzle", confidence: "definite" },
+  { dep: "django", name: "Django", confidence: "definite" },
+  { dep: "flask", name: "Flask", confidence: "definite" },
+  { dep: "fastapi", name: "FastAPI", confidence: "definite" },
+  { dep: "spring-boot", name: "Spring Boot", confidence: "likely" },
+  { dep: "actix-web", name: "Actix Web", confidence: "definite" },
+  { dep: "rocket", name: "Rocket", confidence: "definite" },
+  { dep: "axum", name: "Axum", confidence: "definite" },
+  { dep: "tokio", name: "Tokio", confidence: "definite" },
+  { dep: "gin-gonic/gin", name: "Gin", confidence: "definite" },
+  { dep: "labstack/echo", name: "Echo", confidence: "definite" },
+  { dep: "gofiber/fiber", name: "Fiber", confidence: "definite" },
+  { dep: "laravel/framework", name: "Laravel", confidence: "definite" },
+  { dep: "symfony/framework-bundle", name: "Symfony", confidence: "definite" },
+  { dep: "vitest", name: "Vitest", confidence: "definite" },
+  { dep: "jest", name: "Jest", confidence: "definite" },
+  { dep: "playwright", name: "Playwright", confidence: "definite" },
+  { dep: "@playwright/test", name: "Playwright", confidence: "definite" },
+  { dep: "cypress", name: "Cypress", confidence: "definite" },
+  { dep: "pytest", name: "pytest", confidence: "definite" },
+];
+
+export function detectFrameworks(
+  packages: readonly PackageInfo[],
+): readonly FrameworkDetection[] {
+  const allDeps = new Set<string>();
+  for (const pkg of packages) {
+    for (const dep of pkg.dependencies) {
+      allDeps.add(dep);
+    }
+  }
+
+  const seen = new Set<string>();
+  const results: FrameworkDetection[] = [];
+
+  for (const rule of FRAMEWORK_RULES) {
+    if (allDeps.has(rule.dep) && !seen.has(rule.name)) {
+      seen.add(rule.name);
+      results.push({
+        name: rule.name,
+        confidence: rule.confidence,
+        source: rule.dep,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/pi-compass/src/analyzers/index.ts
+++ b/packages/pi-compass/src/analyzers/index.ts
@@ -1,0 +1,7 @@
+export { buildDirectoryTree, formatDirectoryTree } from "./directory-tree.js";
+export { detectPackages } from "./package-detector.js";
+export { detectFrameworks } from "./framework-detector.js";
+export { detectEntryPoints } from "./entry-point-detector.js";
+export { detectBuildScripts } from "./build-script-detector.js";
+export { detectConventions } from "./convention-detector.js";
+export { detectKeyFiles } from "./key-file-detector.js";

--- a/packages/pi-compass/src/analyzers/key-file-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/key-file-detector.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectKeyFiles } from "./key-file-detector.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-key-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function setup(name: string, files: string[]): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  for (const file of files) {
+    const full = join(dir, file);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, "");
+  }
+  return dir;
+}
+
+describe("detectKeyFiles", () => {
+  it("detects README and LICENSE", () => {
+    const dir = setup("basic", ["README.md", "LICENSE"]);
+    const keys = detectKeyFiles(dir);
+    expect(keys.map((k) => k.path)).toContain("README.md");
+    expect(keys.map((k) => k.path)).toContain("LICENSE");
+  });
+
+  it("detects Dockerfile and docker-compose", () => {
+    const dir = setup("docker", ["Dockerfile", "docker-compose.yml"]);
+    const keys = detectKeyFiles(dir);
+    expect(keys.map((k) => k.path)).toContain("Dockerfile");
+    expect(keys.map((k) => k.path)).toContain("docker-compose.yml");
+  });
+
+  it("detects GitHub workflows directory", () => {
+    const dir = setup("ci", [".github/workflows/ci.yml"]);
+    const keys = detectKeyFiles(dir);
+    expect(keys.map((k) => k.path)).toContain(".github/workflows");
+  });
+
+  it("detects AI agent files", () => {
+    const dir = setup("ai", ["AGENTS.md", "CLAUDE.md"]);
+    const keys = detectKeyFiles(dir);
+    expect(keys.map((k) => k.path)).toContain("AGENTS.md");
+    expect(keys.map((k) => k.path)).toContain("CLAUDE.md");
+  });
+
+  it("returns empty for bare directory", () => {
+    const dir = setup("empty", []);
+    expect(detectKeyFiles(dir)).toEqual([]);
+  });
+});

--- a/packages/pi-compass/src/analyzers/key-file-detector.ts
+++ b/packages/pi-compass/src/analyzers/key-file-detector.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { KeyFile } from "../types.js";
+
+const KEY_FILES: readonly { path: string; description: string }[] = [
+  { path: "README.md", description: "Project documentation" },
+  { path: "LICENSE", description: "License file" },
+  { path: "LICENSE.md", description: "License file" },
+  { path: "CHANGELOG.md", description: "Release history" },
+  { path: "CONTRIBUTING.md", description: "Contribution guidelines" },
+  { path: "SECURITY.md", description: "Security policy" },
+  { path: "ARCHITECTURE.md", description: "Architecture documentation" },
+  { path: "AGENTS.md", description: "AI agent conventions" },
+  { path: "CLAUDE.md", description: "Claude Code instructions" },
+  { path: ".env.example", description: "Environment variable template" },
+  { path: ".env.sample", description: "Environment variable template" },
+  { path: "Dockerfile", description: "Container build definition" },
+  { path: "docker-compose.yml", description: "Container orchestration" },
+  { path: "docker-compose.yaml", description: "Container orchestration" },
+  { path: "Makefile", description: "Build automation" },
+  { path: ".github/workflows", description: "GitHub Actions CI/CD" },
+  { path: ".gitlab-ci.yml", description: "GitLab CI/CD" },
+  { path: "Jenkinsfile", description: "Jenkins pipeline" },
+];
+
+export function detectKeyFiles(cwd: string): readonly KeyFile[] {
+  const results: KeyFile[] = [];
+
+  for (const { path, description } of KEY_FILES) {
+    if (existsSync(join(cwd, path))) {
+      results.push({ path, description });
+    }
+  }
+
+  return results;
+}

--- a/packages/pi-compass/src/analyzers/package-detector.test.ts
+++ b/packages/pi-compass/src/analyzers/package-detector.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectPackages } from "./package-detector.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-pkg-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeDir(name: string): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("detectPackages", () => {
+  it("detects npm package from package.json", () => {
+    const dir = makeDir("npm");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: { react: "^18.0.0" },
+      devDependencies: { vitest: "^3.0.0" },
+    }));
+    const pkgs = detectPackages(dir);
+    expect(pkgs).toHaveLength(1);
+    expect(pkgs[0]?.manager).toBe("npm");
+    expect(pkgs[0]?.name).toBe("my-app");
+    expect(pkgs[0]?.dependencies).toContain("react");
+    expect(pkgs[0]?.dependencies).toContain("vitest");
+  });
+
+  it("detects go module from go.mod", () => {
+    const dir = makeDir("go");
+    writeFileSync(join(dir, "go.mod"), `module github.com/user/app
+
+go 1.21
+
+require (
+\tgithub.com/gin-gonic/gin v1.9.0
+\tgithub.com/joho/godotenv v1.5.1
+)
+`);
+    const pkgs = detectPackages(dir);
+    expect(pkgs).toHaveLength(1);
+    expect(pkgs[0]?.manager).toBe("go");
+    expect(pkgs[0]?.name).toBe("github.com/user/app");
+    expect(pkgs[0]?.dependencies).toContain("github.com/gin-gonic/gin");
+  });
+
+  it("detects pyproject.toml", () => {
+    const dir = makeDir("python");
+    writeFileSync(join(dir, "pyproject.toml"), `[project]
+name = "my-app"
+version = "0.1.0"
+dependencies = [
+  "django>=4.0",
+  "celery>=5.0",
+]
+`);
+    const pkgs = detectPackages(dir);
+    expect(pkgs).toHaveLength(1);
+    expect(pkgs[0]?.manager).toBe("pip");
+    expect(pkgs[0]?.dependencies).toContain("django");
+  });
+
+  it("detects poetry project", () => {
+    const dir = makeDir("poetry");
+    writeFileSync(join(dir, "pyproject.toml"), `[tool.poetry]
+name = "my-app"
+version = "0.1.0"
+`);
+    const pkgs = detectPackages(dir);
+    expect(pkgs[0]?.manager).toBe("poetry");
+  });
+
+  it("returns empty for empty directory", () => {
+    const dir = makeDir("empty");
+    expect(detectPackages(dir)).toEqual([]);
+  });
+
+  it("detects multiple package managers", () => {
+    const dir = makeDir("multi");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "frontend" }));
+    writeFileSync(join(dir, "go.mod"), "module backend\n");
+    const pkgs = detectPackages(dir);
+    expect(pkgs).toHaveLength(2);
+  });
+});

--- a/packages/pi-compass/src/analyzers/package-detector.ts
+++ b/packages/pi-compass/src/analyzers/package-detector.ts
@@ -1,0 +1,87 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { PackageInfo } from "../types.js";
+import { readTextFile, readJsonFile } from "../fs-utils.js";
+
+export function detectPackages(cwd: string): readonly PackageInfo[] {
+  const results: PackageInfo[] = [];
+
+  const npmPkg = readJsonFile(join(cwd, "package.json"));
+  if (npmPkg) {
+    const deps = Object.keys(npmPkg.dependencies ?? {});
+    const devDeps = Object.keys(npmPkg.devDependencies ?? {});
+    const name = typeof npmPkg.name === "string" ? npmPkg.name : "";
+    const version = typeof npmPkg.version === "string" ? npmPkg.version : null;
+    results.push({
+      manager: "npm",
+      name,
+      ...(version ? { version } : {}),
+      dependencies: [...deps, ...devDeps],
+    });
+  }
+
+  const goMod = readTextFile(join(cwd, "go.mod"));
+  if (goMod) {
+    const moduleMatch = goMod.match(/^module\s+(\S+)/m);
+    const deps = [...goMod.matchAll(/^\t(\S+)\s/gm)].map((m) => m[1]!);
+    results.push({
+      manager: "go",
+      name: moduleMatch?.[1] ?? "",
+      dependencies: deps,
+    });
+  }
+
+  const cargo = readTextFile(join(cwd, "Cargo.toml"));
+  if (cargo) {
+    const nameMatch = cargo.match(/^name\s*=\s*"([^"]+)"/m);
+    const versionMatch = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+    const deps = [...cargo.matchAll(/^\[(?:dev-)?dependencies\.([^\]]+)\]/gm)].map((m) => m[1]!);
+    const inlineDeps = [...cargo.matchAll(/^(\w[\w-]*)\s*=\s*(?:"|{)/gm)]
+      .map((m) => m[1]!)
+      .filter((d) => d !== "name" && d !== "version" && d !== "edition" && d !== "authors");
+    const cargoVersion = versionMatch?.[1];
+    results.push({
+      manager: "cargo",
+      name: nameMatch?.[1] ?? "",
+      ...(cargoVersion ? { version: cargoVersion } : {}),
+      dependencies: [...new Set([...deps, ...inlineDeps])],
+    });
+  }
+
+  const pyproject = readTextFile(join(cwd, "pyproject.toml"));
+  if (pyproject) {
+    const nameMatch = pyproject.match(/^name\s*=\s*"([^"]+)"/m);
+    const versionMatch = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
+    const depsSection = pyproject.match(/^dependencies\s*=\s*\[([\s\S]*?)\]/m);
+    const deps = depsSection
+      ? [...depsSection[1]!.matchAll(/"([^">=<\s]+)/g)].map((m) => m[1]!)
+      : [];
+    const hasPoetry = pyproject.includes("[tool.poetry]");
+    const pyVersion = versionMatch?.[1];
+    results.push({
+      manager: hasPoetry ? "poetry" : "pip",
+      name: nameMatch?.[1] ?? "",
+      ...(pyVersion ? { version: pyVersion } : {}),
+      dependencies: deps,
+    });
+  }
+
+  const composer = readJsonFile(join(cwd, "composer.json"));
+  if (composer) {
+    results.push({
+      manager: "composer",
+      name: typeof composer.name === "string" ? composer.name : "",
+      dependencies: Object.keys(composer.require ?? {}),
+    });
+  }
+
+  if (existsSync(join(cwd, "build.gradle")) || existsSync(join(cwd, "build.gradle.kts"))) {
+    results.push({ manager: "gradle", name: "", dependencies: [] });
+  }
+
+  if (existsSync(join(cwd, "pom.xml"))) {
+    results.push({ manager: "maven", name: "", dependencies: [] });
+  }
+
+  return results;
+}

--- a/packages/pi-compass/src/codemap-formatter.test.ts
+++ b/packages/pi-compass/src/codemap-formatter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { formatCodemapMarkdown, truncateCodemap } from "./codemap-formatter.js";
+import type { CodeMap } from "./types.js";
+
+const MINIMAL_MAP: CodeMap = {
+  projectId: "abc",
+  projectName: "test-project",
+  generatedAt: "2026-01-01T00:00:00Z",
+  contentHash: "abcdef1234567890",
+  directoryTree: [
+    { name: "src", type: "dir", children: [{ name: "index.ts", type: "file" }] },
+    { name: "package.json", type: "file" },
+  ],
+  packages: [{ manager: "npm", name: "test-project", version: "1.0.0", dependencies: ["react", "typescript"] }],
+  frameworks: [{ name: "React", confidence: "definite", source: "react" }],
+  entryPoints: [{ path: "src/index.ts", kind: "index" }],
+  buildScripts: [{ name: "build", command: "tsc", source: "package.json" }],
+  conventions: [{ source: "AGENTS.md", content: "Use TDD." }],
+  keyFiles: [{ path: "README.md", description: "Project documentation" }],
+};
+
+describe("formatCodemapMarkdown", () => {
+  it("includes project name in header", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("## Codebase Map: test-project");
+  });
+
+  it("includes directory structure", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("### Directory Structure");
+    expect(md).toContain("src/");
+    expect(md).toContain("index.ts");
+  });
+
+  it("includes packages section", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("### Packages");
+    expect(md).toContain("test-project");
+    expect(md).toContain("npm");
+  });
+
+  it("includes frameworks section", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("### Frameworks");
+    expect(md).toContain("React");
+  });
+
+  it("includes entry points", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("src/index.ts");
+    expect(md).toContain("index");
+  });
+
+  it("includes build scripts", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("build");
+    expect(md).toContain("tsc");
+  });
+
+  it("includes conventions", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("AGENTS.md");
+    expect(md).toContain("Use TDD.");
+  });
+
+  it("includes key files", () => {
+    const md = formatCodemapMarkdown(MINIMAL_MAP);
+    expect(md).toContain("README.md");
+  });
+
+  it("handles empty codemap gracefully", () => {
+    const empty: CodeMap = {
+      ...MINIMAL_MAP,
+      directoryTree: [],
+      packages: [],
+      frameworks: [],
+      entryPoints: [],
+      buildScripts: [],
+      conventions: [],
+      keyFiles: [],
+    };
+    const md = formatCodemapMarkdown(empty);
+    expect(md).toContain("## Codebase Map: test-project");
+    expect(md).not.toContain("### Directory Structure");
+  });
+});
+
+describe("truncateCodemap", () => {
+  it("returns full text when under limit", () => {
+    const text = "short text";
+    expect(truncateCodemap(text, 1000)).toBe(text);
+  });
+
+  it("truncates long text with message", () => {
+    const text = "line1\nline2\nline3\nline4\nline5";
+    const result = truncateCodemap(text, 15);
+    expect(result).toContain("truncated");
+    expect(result.length).toBeLessThan(text.length + 100);
+  });
+});

--- a/packages/pi-compass/src/codemap-formatter.ts
+++ b/packages/pi-compass/src/codemap-formatter.ts
@@ -1,0 +1,90 @@
+import type { CodeMap } from "./types.js";
+import { formatDirectoryTree } from "./analyzers/directory-tree.js";
+
+export function formatCodemapMarkdown(codemap: CodeMap): string {
+  const sections: string[] = [
+    `## Codebase Map: ${codemap.projectName}`,
+    `Generated: ${codemap.generatedAt} | Hash: ${codemap.contentHash}`,
+  ];
+
+  if (codemap.directoryTree.length > 0) {
+    sections.push(
+      "",
+      "### Directory Structure",
+      "```",
+      formatDirectoryTree(codemap.directoryTree),
+      "```",
+    );
+  }
+
+  if (codemap.packages.length > 0) {
+    sections.push("", "### Packages");
+    for (const pkg of codemap.packages) {
+      const version = pkg.version ? ` v${pkg.version}` : "";
+      sections.push(`- **${pkg.name || "(unnamed)"}**${version} (${pkg.manager})`);
+      if (pkg.dependencies.length > 0) {
+        const depList = pkg.dependencies.slice(0, 20).join(", ");
+        const more = pkg.dependencies.length > 20 ? ` (+${pkg.dependencies.length - 20} more)` : "";
+        sections.push(`  Dependencies: ${depList}${more}`);
+      }
+    }
+  }
+
+  if (codemap.frameworks.length > 0) {
+    sections.push("", "### Frameworks");
+    for (const fw of codemap.frameworks) {
+      const version = fw.version ? ` v${fw.version}` : "";
+      const confidence = fw.confidence === "likely" ? " (likely)" : "";
+      sections.push(`- ${fw.name}${version}${confidence}`);
+    }
+  }
+
+  if (codemap.entryPoints.length > 0) {
+    sections.push("", "### Entry Points");
+    for (const ep of codemap.entryPoints) {
+      sections.push(`- \`${ep.path}\` (${ep.kind})`);
+    }
+  }
+
+  if (codemap.buildScripts.length > 0) {
+    sections.push("", "### Build / Test / Deploy");
+    for (const script of codemap.buildScripts) {
+      sections.push(`- **${script.name}**: \`${script.command}\` (${script.source})`);
+    }
+  }
+
+  if (codemap.conventions.length > 0) {
+    sections.push("", "### Conventions");
+    for (const conv of codemap.conventions) {
+      sections.push(``, `#### ${conv.source}`, conv.content);
+    }
+  }
+
+  if (codemap.keyFiles.length > 0) {
+    sections.push("", "### Key Files");
+    for (const kf of codemap.keyFiles) {
+      sections.push(`- \`${kf.path}\` -- ${kf.description}`);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+export function truncateCodemap(markdown: string, maxChars: number): string {
+  if (markdown.length <= maxChars) return markdown;
+
+  const lines = markdown.split("\n");
+  let length = 0;
+  const kept: string[] = [];
+
+  for (const line of lines) {
+    if (length + line.length + 1 > maxChars) {
+      kept.push("", "... (codemap truncated, run /onboard to see full output)");
+      break;
+    }
+    kept.push(line);
+    length += line.length + 1;
+  }
+
+  return kept.join("\n");
+}

--- a/packages/pi-compass/src/codemap-generator.test.ts
+++ b/packages/pi-compass/src/codemap-generator.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateCodemap, computeContentHash, getOrGenerateCodemap } from "./codemap-generator.js";
+import { ensureStorageLayout } from "./storage.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-gen-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function setupProject(name: string, files: Record<string, string>): string {
+  const dir = join(tmpBase, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(dir, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe("computeContentHash", () => {
+  it("produces a 16-char hex hash", () => {
+    const dir = setupProject("hash-basic", { "package.json": "{}" });
+    const hash = computeContentHash(dir);
+    expect(hash).toHaveLength(16);
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("produces different hashes for different content", () => {
+    const dir1 = setupProject("hash-a", { "package.json": '{"name":"a"}' });
+    const dir2 = setupProject("hash-b", { "package.json": '{"name":"b"}' });
+    expect(computeContentHash(dir1)).not.toBe(computeContentHash(dir2));
+  });
+
+  it("produces same hash for same content", () => {
+    const dir = setupProject("hash-stable", { "package.json": '{"name":"x"}' });
+    expect(computeContentHash(dir)).toBe(computeContentHash(dir));
+  });
+});
+
+describe("generateCodemap", () => {
+  it("generates a complete codemap", () => {
+    const dir = setupProject("gen-full", {
+      "package.json": JSON.stringify({
+        name: "test-app",
+        version: "1.0.0",
+        dependencies: { react: "^18.0.0" },
+        scripts: { build: "tsc", test: "vitest" },
+      }),
+      "src/index.ts": "export {}",
+      "README.md": "# Test",
+    });
+    const map = generateCodemap(dir, "proj-1", "test-app");
+    expect(map.projectId).toBe("proj-1");
+    expect(map.projectName).toBe("test-app");
+    expect(map.contentHash).toHaveLength(16);
+    expect(map.packages.length).toBeGreaterThan(0);
+    expect(map.frameworks.map((f) => f.name)).toContain("React");
+    expect(map.entryPoints.map((e) => e.path)).toContain("src/index.ts");
+    expect(map.keyFiles.map((k) => k.path)).toContain("README.md");
+    expect(map.buildScripts.map((s) => s.name)).toContain("build");
+  });
+});
+
+describe("getOrGenerateCodemap", () => {
+  it("generates on first call", () => {
+    const cacheDir = join(tmpBase, "cache-first");
+    ensureStorageLayout("gen-first", cacheDir);
+    const dir = setupProject("get-first", { "package.json": '{"name":"x"}' });
+    const result = getOrGenerateCodemap(dir, "gen-first", "x", cacheDir);
+    expect(result.fromCache).toBe(false);
+    expect(result.stale).toBe(false);
+  });
+
+  it("returns cached on second call", () => {
+    const cacheDir = join(tmpBase, "cache-second");
+    ensureStorageLayout("gen-second", cacheDir);
+    const dir = setupProject("get-second", { "package.json": '{"name":"y"}' });
+    getOrGenerateCodemap(dir, "gen-second", "y", cacheDir);
+    const result = getOrGenerateCodemap(dir, "gen-second", "y", cacheDir);
+    expect(result.fromCache).toBe(true);
+    expect(result.stale).toBe(false);
+  });
+
+  it("detects stale cache when content changes", () => {
+    const cacheDir = join(tmpBase, "cache-stale");
+    ensureStorageLayout("gen-stale", cacheDir);
+    const dir = setupProject("get-stale", { "package.json": '{"name":"z"}' });
+    getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
+
+    writeFileSync(join(dir, "package.json"), '{"name":"z","version":"2.0.0"}');
+    const result = getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
+    expect(result.fromCache).toBe(true);
+    expect(result.stale).toBe(true);
+  });
+});

--- a/packages/pi-compass/src/codemap-generator.ts
+++ b/packages/pi-compass/src/codemap-generator.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { CodeMap, CacheEntry } from "./types.js";
+import {
+  buildDirectoryTree,
+  detectPackages,
+  detectFrameworks,
+  detectEntryPoints,
+  detectBuildScripts,
+  detectConventions,
+  detectKeyFiles,
+} from "./analyzers/index.js";
+import { loadCachedCodemap, saveCachedCodemap } from "./storage.js";
+
+const HASH_FILES = [
+  "package.json",
+  "package-lock.json",
+  "tsconfig.json",
+  "go.mod",
+  "go.sum",
+  "Cargo.toml",
+  "Cargo.lock",
+  "pyproject.toml",
+  "composer.json",
+  "composer.lock",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+];
+
+export function computeContentHash(cwd: string): string {
+  const hash = createHash("sha256");
+
+  for (const file of HASH_FILES) {
+    try {
+      hash.update(readFileSync(join(cwd, file), "utf-8"));
+    } catch {
+      // absent
+    }
+  }
+
+  try {
+    const entries = readdirSync(cwd).sort();
+    hash.update(entries.join("\n"));
+  } catch {
+    // absent
+  }
+
+  return hash.digest("hex").substring(0, 16);
+}
+
+export function generateCodemap(
+  cwd: string,
+  projectId: string,
+  projectName: string,
+): CodeMap {
+  const directoryTree = buildDirectoryTree(cwd);
+  const packages = detectPackages(cwd);
+  const frameworks = detectFrameworks(packages);
+  const entryPoints = detectEntryPoints(cwd, packages);
+  const buildScripts = detectBuildScripts(cwd);
+  const conventions = detectConventions(cwd);
+  const keyFiles = detectKeyFiles(cwd);
+
+  return {
+    projectId,
+    projectName,
+    generatedAt: new Date().toISOString(),
+    contentHash: computeContentHash(cwd),
+    directoryTree,
+    packages,
+    frameworks,
+    entryPoints,
+    buildScripts,
+    conventions,
+    keyFiles,
+  };
+}
+
+export interface CodemapResult {
+  readonly codemap: CodeMap;
+  readonly fromCache: boolean;
+  readonly stale: boolean;
+}
+
+export function getOrGenerateCodemap(
+  cwd: string,
+  projectId: string,
+  projectName: string,
+  baseDir?: string,
+): CodemapResult {
+  const cached = loadCachedCodemap(projectId, baseDir);
+  if (cached) {
+    const currentHash = computeContentHash(cwd);
+    if (cached.contentHash === currentHash) {
+      return { codemap: cached.data, fromCache: true, stale: false };
+    }
+    return { codemap: cached.data, fromCache: true, stale: true };
+  }
+
+  const codemap = generateCodemap(cwd, projectId, projectName);
+  const entry: CacheEntry<CodeMap> = {
+    data: codemap,
+    contentHash: codemap.contentHash,
+    createdAt: codemap.generatedAt,
+  };
+  saveCachedCodemap(projectId, entry, baseDir);
+  return { codemap, fromCache: false, stale: false };
+}

--- a/packages/pi-compass/src/codemap-injector.test.ts
+++ b/packages/pi-compass/src/codemap-injector.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { buildCodemapInjection, handleBeforeAgentStart } from "./codemap-injector.js";
+import type { CodeMap, CompassState, CacheEntry } from "./types.js";
+
+const MINIMAL_MAP: CodeMap = {
+  projectId: "abc",
+  projectName: "test",
+  generatedAt: "2026-01-01T00:00:00Z",
+  contentHash: "hash123",
+  directoryTree: [{ name: "src", type: "dir" }],
+  packages: [],
+  frameworks: [],
+  entryPoints: [],
+  buildScripts: [],
+  conventions: [],
+  keyFiles: [],
+};
+
+const CACHED: CacheEntry<CodeMap> = {
+  data: MINIMAL_MAP,
+  contentHash: "hash123",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+function makeState(overrides: Partial<CompassState> = {}): CompassState {
+  return {
+    project: { id: "abc", name: "test", root: "/tmp", remote: "" },
+    turnCount: 0,
+    codemapInjected: false,
+    cachedCodemap: CACHED,
+    stale: false,
+    ...overrides,
+  };
+}
+
+describe("buildCodemapInjection", () => {
+  it("returns markdown injection block", () => {
+    const result = buildCodemapInjection(MINIMAL_MAP, false, 10000);
+    expect(result).toContain("Codebase Map: test");
+  });
+
+  it("includes stale note when stale", () => {
+    const result = buildCodemapInjection(MINIMAL_MAP, true, 10000);
+    expect(result).toContain("outdated");
+    expect(result).toContain("/onboard");
+  });
+
+  it("does not include stale note when fresh", () => {
+    const result = buildCodemapInjection(MINIMAL_MAP, false, 10000);
+    expect(result).not.toContain("outdated");
+  });
+});
+
+describe("handleBeforeAgentStart", () => {
+  it("injects codemap on first turn", () => {
+    const event = { type: "before_agent_start" as const, prompt: "", systemPrompt: "base" };
+    const state = makeState({ codemapInjected: false });
+    const result = handleBeforeAgentStart(event, state, 10000);
+    expect(result).toBeDefined();
+    expect(result!.systemPrompt).toContain("base");
+    expect(result!.systemPrompt).toContain("Codebase Map");
+  });
+
+  it("returns undefined when already injected", () => {
+    const event = { type: "before_agent_start" as const, prompt: "", systemPrompt: "base" };
+    const state = makeState({ codemapInjected: true });
+    expect(handleBeforeAgentStart(event, state, 10000)).toBeUndefined();
+  });
+
+  it("returns undefined when no cached codemap", () => {
+    const event = { type: "before_agent_start" as const, prompt: "", systemPrompt: "base" };
+    const state = makeState({ cachedCodemap: null });
+    expect(handleBeforeAgentStart(event, state, 10000)).toBeUndefined();
+  });
+});

--- a/packages/pi-compass/src/codemap-injector.ts
+++ b/packages/pi-compass/src/codemap-injector.ts
@@ -1,0 +1,44 @@
+import type { CodeMap, CompassState } from "./types.js";
+import { formatCodemapMarkdown, truncateCodemap } from "./codemap-formatter.js";
+
+export interface BeforeAgentStartEvent {
+  type: "before_agent_start";
+  prompt: string;
+  systemPrompt: string;
+}
+
+export interface InjectionResult {
+  systemPrompt: string;
+}
+
+export function buildCodemapInjection(
+  codemap: CodeMap,
+  stale: boolean,
+  maxChars: number,
+): string {
+  const markdown = formatCodemapMarkdown(codemap);
+  const truncated = truncateCodemap(markdown, maxChars);
+  const staleNote = stale
+    ? "\n\n> This codemap may be outdated. Run `/onboard` to refresh."
+    : "";
+
+  return `\n\n${truncated}${staleNote}`;
+}
+
+export function handleBeforeAgentStart(
+  event: BeforeAgentStartEvent,
+  state: CompassState,
+  maxChars: number,
+): InjectionResult | undefined {
+  if (state.codemapInjected) return undefined;
+  if (!state.cachedCodemap) return undefined;
+
+  const block = buildCodemapInjection(
+    state.cachedCodemap.data,
+    state.stale,
+    maxChars,
+  );
+  if (!block) return undefined;
+
+  return { systemPrompt: event.systemPrompt + block };
+}

--- a/packages/pi-compass/src/fs-utils.ts
+++ b/packages/pi-compass/src/fs-utils.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+export function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export function readJsonFile(path: string): Record<string, unknown> | null {
+  const text = readTextFile(path);
+  if (text === null) return null;
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/packages/pi-compass/src/index.test.ts
+++ b/packages/pi-compass/src/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import extension from "./index.js";
+
+function makeMockPi(): ExtensionAPI {
+  return {
+    on: vi.fn(),
+    registerCommand: vi.fn(),
+    registerTool: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as ExtensionAPI;
+}
+
+describe("extension entry point", () => {
+  it("registers 3 event handlers", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    expect(vi.mocked(pi.on)).toHaveBeenCalledTimes(3);
+  });
+
+  it("registers session_start handler", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("session_start");
+  });
+
+  it("registers before_agent_start handler", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("before_agent_start");
+  });
+
+  it("registers turn_end handler", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    const events = vi.mocked(pi.on).mock.calls.map(([e]) => e);
+    expect(events).toContain("turn_end");
+  });
+
+  it("registers 2 commands", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    expect(vi.mocked(pi.registerCommand)).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers onboard command", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    const commands = vi.mocked(pi.registerCommand).mock.calls.map(([name]) => name);
+    expect(commands).toContain("onboard");
+  });
+
+  it("registers tour command", () => {
+    const pi = makeMockPi();
+    extension(pi);
+    const commands = vi.mocked(pi.registerCommand).mock.calls.map(([name]) => name);
+    expect(commands).toContain("tour");
+  });
+});

--- a/packages/pi-compass/src/index.ts
+++ b/packages/pi-compass/src/index.ts
@@ -1,0 +1,90 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+
+import { detectProject } from "./project.js";
+import { ensureStorageLayout, loadCachedCodemap } from "./storage.js";
+import { computeContentHash } from "./codemap-generator.js";
+import {
+  handleBeforeAgentStart as buildInjection,
+  type BeforeAgentStartEvent,
+} from "./codemap-injector.js";
+import { handleOnboardCommand, COMMAND_NAME as ONBOARD_CMD } from "./onboard-command.js";
+import { handleTourCommand, COMMAND_NAME as TOUR_CMD } from "./tour-command.js";
+import { registerOnboardTools } from "./onboard-tools.js";
+import type { CompassState } from "./types.js";
+
+const DEFAULT_MAX_INJECTION_CHARS = 6000;
+
+export default function (pi: ExtensionAPI): void {
+  let state: CompassState = {
+    project: null,
+    turnCount: 0,
+    codemapInjected: false,
+    cachedCodemap: null,
+    stale: false,
+  };
+
+  const stateRef = {
+    get: () => state,
+    set: (s: CompassState) => { state = s; },
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    try {
+      const project = await detectProject(pi, ctx.cwd);
+      ensureStorageLayout(project.id);
+
+      const cached = loadCachedCodemap(project.id);
+      let stale = false;
+      if (cached) {
+        const currentHash = computeContentHash(project.root);
+        stale = cached.contentHash !== currentHash;
+      }
+
+      state = { ...state, project, cachedCodemap: cached, stale };
+
+      registerOnboardTools(pi, stateRef);
+    } catch (err) {
+      console.error("[pi-compass] session_start error:", err);
+    }
+  });
+
+  pi.on("before_agent_start", (event, _ctx) => {
+    try {
+      if (!state.project) return;
+      const result = buildInjection(
+        event as BeforeAgentStartEvent,
+        state,
+        DEFAULT_MAX_INJECTION_CHARS,
+      );
+      if (result) {
+        state = { ...state, codemapInjected: true };
+        return result;
+      }
+    } catch (err) {
+      console.error("[pi-compass] before_agent_start error:", err);
+    }
+  });
+
+  pi.on("turn_end", (_event, _ctx) => {
+    try {
+      state = { ...state, turnCount: state.turnCount + 1 };
+    } catch (err) {
+      console.error("[pi-compass] turn_end error:", err);
+    }
+  });
+
+  pi.registerCommand(ONBOARD_CMD, {
+    description: "Generate a structured codebase map for the current project",
+    handler: (args: string, ctx: ExtensionCommandContext) =>
+      handleOnboardCommand(args, ctx, pi, stateRef),
+  });
+
+  pi.registerCommand(TOUR_CMD, {
+    description: "Take a guided tour of a specific area of the codebase",
+    handler: (args: string, ctx: ExtensionCommandContext) =>
+      handleTourCommand(args, ctx, pi, stateRef),
+  });
+}

--- a/packages/pi-compass/src/onboard-command.test.ts
+++ b/packages/pi-compass/src/onboard-command.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { handleOnboardCommand } from "./onboard-command.js";
+import type { StateRef } from "./types.js";
+import type { CompassState } from "./types.js";
+import { ensureStorageLayout } from "./storage.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-onboard-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeMockCtx(): ExtensionCommandContext {
+  return { ui: { notify: vi.fn() } } as unknown as ExtensionCommandContext;
+}
+
+function makeMockPi(): ExtensionAPI {
+  return { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+}
+
+function makeState(root: string): CompassState {
+  return {
+    project: { id: "test-id", name: "test", root, remote: "" },
+    turnCount: 0,
+    codemapInjected: false,
+    cachedCodemap: null,
+    stale: false,
+  };
+}
+
+describe("handleOnboardCommand", () => {
+  it("shows error when no project detected", async () => {
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const ref: StateRef = {
+      get: () => ({ project: null, turnCount: 0, codemapInjected: false, cachedCodemap: null, stale: false }),
+      set: vi.fn(),
+    };
+    await handleOnboardCommand("", ctx, pi, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("No project"),
+      "error",
+    );
+  });
+
+  it("generates codemap and sends message", async () => {
+    const dir = join(tmpBase, "gen");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "test" }));
+    ensureStorageLayout("test-id");
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const state = makeState(dir);
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+
+    await handleOnboardCommand("", ctx, pi, ref);
+    expect(vi.mocked(pi.sendUserMessage)).toHaveBeenCalledWith(
+      expect.stringContaining("codebase map"),
+      { deliverAs: "followUp" },
+    );
+  });
+});

--- a/packages/pi-compass/src/onboard-command.ts
+++ b/packages/pi-compass/src/onboard-command.ts
@@ -1,0 +1,60 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { generateCodemap } from "./codemap-generator.js";
+import { formatCodemapMarkdown } from "./codemap-formatter.js";
+import { saveCachedCodemap } from "./storage.js";
+import type { StateRef, CacheEntry, CodeMap } from "./types.js";
+
+export const COMMAND_NAME = "onboard";
+
+export async function handleOnboardCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  stateRef: StateRef,
+): Promise<void> {
+  const state = stateRef.get();
+  if (!state.project) {
+    ctx.ui.notify("No project detected. Run from within a git repository.", "error");
+    return;
+  }
+
+  const forceRefresh = args.trim() === "--refresh";
+
+  if (!forceRefresh && state.cachedCodemap && !state.stale) {
+    const markdown = formatCodemapMarkdown(state.cachedCodemap.data);
+    pi.sendUserMessage(
+      `Here is the cached codebase map for ${state.project.name}:\n\n${markdown}`,
+      { deliverAs: "followUp" },
+    );
+    return;
+  }
+
+  const codemap = generateCodemap(
+    state.project.root,
+    state.project.id,
+    state.project.name,
+  );
+
+  const entry: CacheEntry<CodeMap> = {
+    data: codemap,
+    contentHash: codemap.contentHash,
+    createdAt: codemap.generatedAt,
+  };
+  saveCachedCodemap(state.project.id, entry);
+
+  stateRef.set({
+    ...state,
+    cachedCodemap: entry,
+    stale: false,
+    codemapInjected: false,
+  });
+
+  const markdown = formatCodemapMarkdown(codemap);
+  pi.sendUserMessage(
+    `Here is the codebase map for ${state.project.name}:\n\n${markdown}`,
+    { deliverAs: "followUp" },
+  );
+}

--- a/packages/pi-compass/src/onboard-tools.test.ts
+++ b/packages/pi-compass/src/onboard-tools.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerOnboardTools } from "./onboard-tools.js";
+import type { StateRef } from "./types.js";
+import type { CompassState, CodeMap, CacheEntry } from "./types.js";
+import { ensureStorageLayout } from "./storage.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-tools-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+type ToolDef = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: unknown,
+  ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+};
+
+function registerAndCapture(stateRef: StateRef): Map<string, ToolDef> {
+  const tools = new Map<string, ToolDef>();
+  const mockPi = {
+    registerTool: vi.fn((def: ToolDef) => { tools.set(def.name, def); }),
+  } as unknown as ExtensionAPI;
+  registerOnboardTools(mockPi, stateRef);
+  return tools;
+}
+
+describe("registerOnboardTools", () => {
+  it("registers 2 tools", () => {
+    const mockPi = { registerTool: vi.fn() } as unknown as ExtensionAPI;
+    const ref: StateRef = {
+      get: () => ({ project: null, turnCount: 0, codemapInjected: false, cachedCodemap: null, stale: false }),
+      set: vi.fn(),
+    };
+    registerOnboardTools(mockPi, ref);
+    expect(vi.mocked(mockPi.registerTool)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("codebase_map tool", () => {
+  it("generates codemap for project", async () => {
+    const dir = join(tmpBase, "map-tool");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "test" }));
+    ensureStorageLayout("map-id");
+
+    const state: CompassState = {
+      project: { id: "map-id", name: "test", root: dir, remote: "" },
+      turnCount: 0,
+      codemapInjected: false,
+      cachedCodemap: null,
+      stale: false,
+    };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("codebase_map")!;
+
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("Codebase Map");
+  });
+
+  it("throws when no project", async () => {
+    const state: CompassState = { project: null, turnCount: 0, codemapInjected: false, cachedCodemap: null, stale: false };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("codebase_map")!;
+
+    await expect(tool.execute("c1", {}, undefined, null, null)).rejects.toThrow("No project");
+  });
+});
+
+describe("code_tour tool", () => {
+  it("lists topics when no topic param", async () => {
+    const dir = join(tmpBase, "tour-tool-list");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    ensureStorageLayout("tour-id");
+
+    const codemap: CodeMap = {
+      projectId: "tour-id",
+      projectName: "test",
+      generatedAt: "",
+      contentHash: "hash",
+      directoryTree: [{ name: "src", type: "dir" }],
+      packages: [],
+      frameworks: [],
+      entryPoints: [],
+      buildScripts: [],
+      conventions: [],
+      keyFiles: [],
+    };
+    const cached: CacheEntry<CodeMap> = { data: codemap, contentHash: "hash", createdAt: "" };
+    const state: CompassState = {
+      project: { id: "tour-id", name: "test", root: dir, remote: "" },
+      turnCount: 0,
+      codemapInjected: false,
+      cachedCodemap: cached,
+      stale: false,
+    };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+    const tools = registerAndCapture(ref);
+    const tool = tools.get("code_tour")!;
+
+    const result = await tool.execute("c1", {}, undefined, null, null);
+    expect(result.content[0]?.text).toContain("src");
+  });
+});

--- a/packages/pi-compass/src/onboard-tools.ts
+++ b/packages/pi-compass/src/onboard-tools.ts
@@ -1,0 +1,116 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import type { StateRef } from "./types.js";
+import { getOrGenerateCodemap } from "./codemap-generator.js";
+import { formatCodemapMarkdown } from "./codemap-formatter.js";
+import { detectAvailableTopics, getOrGenerateTour, formatTourMarkdown } from "./tour-generator.js";
+
+const CodemapParams = Type.Object({});
+
+const TourParams = Type.Object({
+  topic: Type.Optional(
+    Type.String({ description: "Tour topic (e.g., 'auth', 'api', 'testing'). Omit to list available topics." }),
+  ),
+});
+
+function createCodemapTool(stateRef: StateRef) {
+  return {
+    name: "codebase_map" as const,
+    label: "Codebase Map",
+    description: "Returns a structured map of the current codebase including directory tree, packages, frameworks, entry points, build scripts, and conventions",
+    promptSnippet: "Get or generate a structured map of the current codebase",
+    parameters: CodemapParams,
+    async execute(
+      _toolCallId: string,
+      _params: Record<string, never>,
+      _signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const state = stateRef.get();
+      if (!state.project) {
+        throw new Error("No project detected.");
+      }
+
+      const { codemap } = getOrGenerateCodemap(
+        state.project.root,
+        state.project.id,
+        state.project.name,
+      );
+
+      const markdown = formatCodemapMarkdown(codemap);
+      return {
+        content: [{ type: "text" as const, text: markdown }],
+        details: { projectId: codemap.projectId, contentHash: codemap.contentHash },
+      };
+    },
+  };
+}
+
+function createTourTool(stateRef: StateRef) {
+  return {
+    name: "code_tour" as const,
+    label: "Code Tour",
+    description: "Returns a guided walkthrough of a specific area of the codebase, or lists available topics",
+    promptSnippet: "Get a guided code tour for a specific topic or area",
+    parameters: TourParams,
+    async execute(
+      _toolCallId: string,
+      params: { topic?: string },
+      _signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const state = stateRef.get();
+      if (!state.project) {
+        throw new Error("No project detected.");
+      }
+
+      const codemap = state.cachedCodemap?.data
+        ?? getOrGenerateCodemap(state.project.root, state.project.id, state.project.name).codemap;
+
+      if (!params.topic) {
+        const topics = detectAvailableTopics(state.project.root, codemap);
+        return {
+          content: [{
+            type: "text" as const,
+            text: topics.length > 0
+              ? `Available tour topics: ${topics.join(", ")}`
+              : "No tour topics detected.",
+          }],
+          details: { topics } as Record<string, unknown>,
+        };
+      }
+
+      const tour = getOrGenerateTour(
+        state.project.root,
+        params.topic,
+        codemap,
+        state.project.id,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: formatTourMarkdown(tour) }],
+        details: { topic: tour.topic, steps: tour.steps.length } as Record<string, unknown>,
+      };
+    },
+  };
+}
+
+export function registerOnboardTools(
+  pi: ExtensionAPI,
+  stateRef: StateRef,
+): void {
+  const guidelines = [
+    "Use codebase_map to understand the overall project structure. Use code_tour to walk through specific areas in detail.",
+  ];
+
+  pi.registerTool({
+    ...createCodemapTool(stateRef),
+    promptGuidelines: guidelines,
+  });
+  pi.registerTool({
+    ...createTourTool(stateRef),
+    promptGuidelines: guidelines,
+  });
+}

--- a/packages/pi-compass/src/project.test.ts
+++ b/packages/pi-compass/src/project.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { detectProject } from "./project.js";
+
+function makeMockPi(execResults: Record<string, { code: number; stdout: string; stderr: string }>): ExtensionAPI {
+  return {
+    exec: vi.fn(async (cmd: string, args: string[]) => {
+      const key = `${cmd} ${args.join(" ")}`;
+      return execResults[key] ?? { code: 1, stdout: "", stderr: "not found" };
+    }),
+  } as unknown as ExtensionAPI;
+}
+
+describe("detectProject", () => {
+  it("uses git remote URL when available", async () => {
+    const pi = makeMockPi({
+      "git remote get-url origin": { code: 0, stdout: "https://github.com/user/repo.git\n", stderr: "" },
+    });
+    const project = await detectProject(pi, "/home/user/repo");
+    expect(project.name).toBe("repo");
+    expect(project.remote).toBe("https://github.com/user/repo.git");
+    expect(project.id).toHaveLength(12);
+    expect(project.root).toBe("/home/user/repo");
+  });
+
+  it("falls back to repo root when no remote", async () => {
+    const pi = makeMockPi({
+      "git rev-parse --show-toplevel": { code: 0, stdout: "/home/user/repo\n", stderr: "" },
+    });
+    const project = await detectProject(pi, "/home/user/repo");
+    expect(project.id).toHaveLength(12);
+    expect(project.remote).toBe("");
+    expect(project.root).toBe("/home/user/repo");
+  });
+
+  it("falls back to global when not in a git repo", async () => {
+    const pi = makeMockPi({});
+    const project = await detectProject(pi, "/tmp/scratch");
+    expect(project.id).toBe("global");
+    expect(project.name).toBe("scratch");
+  });
+
+  it("produces consistent hashes for the same remote", async () => {
+    const pi = makeMockPi({
+      "git remote get-url origin": { code: 0, stdout: "https://github.com/user/repo.git\n", stderr: "" },
+    });
+    const p1 = await detectProject(pi, "/home/user/repo");
+    const p2 = await detectProject(pi, "/home/user/repo");
+    expect(p1.id).toBe(p2.id);
+  });
+});

--- a/packages/pi-compass/src/project.ts
+++ b/packages/pi-compass/src/project.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ProjectInfo } from "./types.js";
+
+function hashString(input: string): string {
+  return createHash("sha256").update(input).digest("hex").substring(0, 12);
+}
+
+export async function detectProject(
+  pi: ExtensionAPI,
+  cwd: string,
+): Promise<ProjectInfo> {
+  const name = basename(cwd);
+
+  const remoteResult = await pi.exec("git", ["remote", "get-url", "origin"], { cwd });
+  if (remoteResult.code === 0) {
+    const remote = remoteResult.stdout.trim();
+    return { id: hashString(remote), name, root: cwd, remote };
+  }
+
+  const rootResult = await pi.exec("git", ["rev-parse", "--show-toplevel"], { cwd });
+  if (rootResult.code === 0) {
+    const root = rootResult.stdout.trim();
+    return { id: hashString(root), name, root, remote: "" };
+  }
+
+  return { id: "global", name, root: cwd, remote: "" };
+}

--- a/packages/pi-compass/src/storage.test.ts
+++ b/packages/pi-compass/src/storage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getBaseDir,
+  getProjectDir,
+  getCodemapPath,
+  getToursDir,
+  getTourPath,
+  ensureStorageLayout,
+  loadCachedCodemap,
+  saveCachedCodemap,
+  loadCachedTour,
+  saveCachedTour,
+} from "./storage.js";
+import type { CacheEntry, CodeMap, CodeTour } from "./types.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-storage-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+const MINIMAL_CODEMAP: CodeMap = {
+  projectId: "abc123",
+  projectName: "test-project",
+  generatedAt: "2026-01-01T00:00:00Z",
+  contentHash: "hash123",
+  directoryTree: [],
+  packages: [],
+  frameworks: [],
+  entryPoints: [],
+  buildScripts: [],
+  conventions: [],
+  keyFiles: [],
+};
+
+const MINIMAL_TOUR: CodeTour = {
+  projectId: "abc123",
+  topic: "auth",
+  generatedAt: "2026-01-01T00:00:00Z",
+  steps: [{ file: "src/auth.ts", description: "Auth module" }],
+};
+
+describe("path helpers", () => {
+  it("getBaseDir returns a path under ~/.pi/compass", () => {
+    expect(getBaseDir()).toContain(".pi");
+    expect(getBaseDir()).toContain("compass");
+  });
+
+  it("getProjectDir nests under projects/", () => {
+    expect(getProjectDir("abc", tmpBase)).toBe(join(tmpBase, "projects", "abc"));
+  });
+
+  it("getCodemapPath returns codemap.json", () => {
+    expect(getCodemapPath("abc", tmpBase)).toBe(join(tmpBase, "projects", "abc", "codemap.json"));
+  });
+
+  it("getToursDir returns tours/", () => {
+    expect(getToursDir("abc", tmpBase)).toBe(join(tmpBase, "projects", "abc", "tours"));
+  });
+
+  it("getTourPath returns topic.json", () => {
+    expect(getTourPath("abc", "auth", tmpBase)).toBe(join(tmpBase, "projects", "abc", "tours", "auth.json"));
+  });
+});
+
+describe("ensureStorageLayout", () => {
+  it("creates project and tours directories", () => {
+    ensureStorageLayout("layout-test", tmpBase);
+    expect(existsSync(getToursDir("layout-test", tmpBase))).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    ensureStorageLayout("idem-test", tmpBase);
+    ensureStorageLayout("idem-test", tmpBase);
+  });
+});
+
+describe("codemap cache", () => {
+  it("returns null when no cache exists", () => {
+    ensureStorageLayout("no-cache", tmpBase);
+    expect(loadCachedCodemap("no-cache", tmpBase)).toBeNull();
+  });
+
+  it("round-trips codemap cache", () => {
+    ensureStorageLayout("roundtrip", tmpBase);
+    const entry: CacheEntry<CodeMap> = {
+      data: MINIMAL_CODEMAP,
+      contentHash: "hash123",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    saveCachedCodemap("roundtrip", entry, tmpBase);
+    const loaded = loadCachedCodemap("roundtrip", tmpBase);
+    expect(loaded).toEqual(entry);
+  });
+});
+
+describe("tour cache", () => {
+  it("returns null when no tour cached", () => {
+    ensureStorageLayout("no-tour", tmpBase);
+    expect(loadCachedTour("no-tour", "auth", tmpBase)).toBeNull();
+  });
+
+  it("round-trips tour cache", () => {
+    ensureStorageLayout("tour-rt", tmpBase);
+    const entry: CacheEntry<CodeTour> = {
+      data: MINIMAL_TOUR,
+      contentHash: "hash456",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    saveCachedTour("tour-rt", "auth", entry, tmpBase);
+    const loaded = loadCachedTour("tour-rt", "auth", tmpBase);
+    expect(loaded).toEqual(entry);
+  });
+});

--- a/packages/pi-compass/src/storage.ts
+++ b/packages/pi-compass/src/storage.ts
@@ -1,0 +1,82 @@
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { CodeMap, CodeTour, CacheEntry } from "./types.js";
+
+export function getBaseDir(): string {
+  return join(homedir(), ".pi", "compass");
+}
+
+export function getProjectDir(projectId: string, baseDir = getBaseDir()): string {
+  return join(baseDir, "projects", projectId);
+}
+
+export function getCodemapPath(projectId: string, baseDir = getBaseDir()): string {
+  return join(getProjectDir(projectId, baseDir), "codemap.json");
+}
+
+export function getToursDir(projectId: string, baseDir = getBaseDir()): string {
+  return join(getProjectDir(projectId, baseDir), "tours");
+}
+
+export function getTourPath(projectId: string, topic: string, baseDir = getBaseDir()): string {
+  return join(getToursDir(projectId, baseDir), `${topic}.json`);
+}
+
+export function ensureStorageLayout(projectId: string, baseDir = getBaseDir()): void {
+  mkdirSync(getToursDir(projectId, baseDir), { recursive: true });
+}
+
+export function loadCachedCodemap(
+  projectId: string,
+  baseDir = getBaseDir(),
+): CacheEntry<CodeMap> | null {
+  try {
+    const raw = readFileSync(getCodemapPath(projectId, baseDir), "utf-8");
+    return JSON.parse(raw) as CacheEntry<CodeMap>;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedCodemap(
+  projectId: string,
+  entry: CacheEntry<CodeMap>,
+  baseDir = getBaseDir(),
+): void {
+  writeFileSync(
+    getCodemapPath(projectId, baseDir),
+    JSON.stringify(entry, null, 2),
+    "utf-8",
+  );
+}
+
+export function loadCachedTour(
+  projectId: string,
+  topic: string,
+  baseDir = getBaseDir(),
+): CacheEntry<CodeTour> | null {
+  try {
+    const raw = readFileSync(getTourPath(projectId, topic, baseDir), "utf-8");
+    return JSON.parse(raw) as CacheEntry<CodeTour>;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedTour(
+  projectId: string,
+  topic: string,
+  entry: CacheEntry<CodeTour>,
+  baseDir = getBaseDir(),
+): void {
+  writeFileSync(
+    getTourPath(projectId, topic, baseDir),
+    JSON.stringify(entry, null, 2),
+    "utf-8",
+  );
+}

--- a/packages/pi-compass/src/tour-command.test.ts
+++ b/packages/pi-compass/src/tour-command.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { handleTourCommand } from "./tour-command.js";
+import type { StateRef } from "./types.js";
+import type { CompassState, CodeMap, CacheEntry } from "./types.js";
+import { ensureStorageLayout } from "./storage.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-tourcmd-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeMockCtx(): ExtensionCommandContext {
+  return { ui: { notify: vi.fn() } } as unknown as ExtensionCommandContext;
+}
+
+function makeMockPi(): ExtensionAPI {
+  return { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+}
+
+const CODEMAP: CodeMap = {
+  projectId: "abc",
+  projectName: "test",
+  generatedAt: "2026-01-01T00:00:00Z",
+  contentHash: "hash",
+  directoryTree: [{ name: "src", type: "dir" }],
+  packages: [],
+  frameworks: [],
+  entryPoints: [],
+  buildScripts: [],
+  conventions: [],
+  keyFiles: [],
+};
+
+describe("handleTourCommand", () => {
+  it("lists topics when no args", async () => {
+    const dir = join(tmpBase, "list");
+    mkdirSync(join(dir, "src"), { recursive: true });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const cached: CacheEntry<CodeMap> = { data: CODEMAP, contentHash: "hash", createdAt: "" };
+    const state: CompassState = {
+      project: { id: "abc", name: "test", root: dir, remote: "" },
+      turnCount: 0,
+      codemapInjected: false,
+      cachedCodemap: cached,
+      stale: false,
+    };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+
+    await handleTourCommand("", ctx, pi, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("src"),
+      "info",
+    );
+  });
+
+  it("generates tour for a topic", async () => {
+    const dir = join(tmpBase, "topic");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), "");
+    ensureStorageLayout("abc");
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const cached: CacheEntry<CodeMap> = { data: CODEMAP, contentHash: "hash", createdAt: "" };
+    const state: CompassState = {
+      project: { id: "abc", name: "test", root: dir, remote: "" },
+      turnCount: 0,
+      codemapInjected: false,
+      cachedCodemap: cached,
+      stale: false,
+    };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+
+    await handleTourCommand("src", ctx, pi, ref);
+    expect(vi.mocked(pi.sendUserMessage)).toHaveBeenCalled();
+  });
+
+  it("shows error when no project", async () => {
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const state: CompassState = { project: null, turnCount: 0, codemapInjected: false, cachedCodemap: null, stale: false };
+    const ref: StateRef = { get: () => state, set: vi.fn() };
+
+    await handleTourCommand("src", ctx, pi, ref);
+    expect(vi.mocked(ctx.ui.notify)).toHaveBeenCalledWith(
+      expect.stringContaining("No project"),
+      "error",
+    );
+  });
+});

--- a/packages/pi-compass/src/tour-command.ts
+++ b/packages/pi-compass/src/tour-command.ts
@@ -1,0 +1,50 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { detectAvailableTopics, getOrGenerateTour, formatTourMarkdown } from "./tour-generator.js";
+import type { StateRef } from "./types.js";
+import { getOrGenerateCodemap } from "./codemap-generator.js";
+
+export const COMMAND_NAME = "tour";
+
+export async function handleTourCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  stateRef: StateRef,
+): Promise<void> {
+  const state = stateRef.get();
+  if (!state.project) {
+    ctx.ui.notify("No project detected. Run from within a git repository.", "error");
+    return;
+  }
+
+  const codemap = state.cachedCodemap?.data
+    ?? getOrGenerateCodemap(state.project.root, state.project.id, state.project.name).codemap;
+
+  const topic = args.trim();
+
+  if (!topic) {
+    const topics = detectAvailableTopics(state.project.root, codemap);
+    if (topics.length === 0) {
+      ctx.ui.notify("No tour topics detected in this project.", "info");
+      return;
+    }
+    ctx.ui.notify(`Available tour topics:\n${topics.map((t) => `  - ${t}`).join("\n")}\n\nUsage: /tour <topic>`, "info");
+    return;
+  }
+
+  const tour = getOrGenerateTour(
+    state.project.root,
+    topic,
+    codemap,
+    state.project.id,
+  );
+
+  const markdown = formatTourMarkdown(tour);
+  pi.sendUserMessage(
+    `${markdown}\n\nAsk me about any of these files for more detail.`,
+    { deliverAs: "followUp" },
+  );
+}

--- a/packages/pi-compass/src/tour-generator.test.ts
+++ b/packages/pi-compass/src/tour-generator.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectAvailableTopics, generateTour, formatTourMarkdown } from "./tour-generator.js";
+import type { CodeMap } from "./types.js";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "compass-tour-test-"));
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+function makeCodemap(overrides: Partial<CodeMap> = {}): CodeMap {
+  return {
+    projectId: "abc",
+    projectName: "test",
+    generatedAt: "2026-01-01T00:00:00Z",
+    contentHash: "hash",
+    directoryTree: [
+      { name: "src", type: "dir" },
+      { name: "tests", type: "dir" },
+      { name: ".github", type: "dir" },
+    ],
+    packages: [],
+    frameworks: [],
+    entryPoints: [],
+    buildScripts: [],
+    conventions: [],
+    keyFiles: [{ path: ".github/workflows", description: "CI" }],
+    ...overrides,
+  };
+}
+
+describe("detectAvailableTopics", () => {
+  it("includes top-level directories", () => {
+    const topics = detectAvailableTopics(tmpBase, makeCodemap());
+    expect(topics).toContain("src");
+  });
+
+  it("detects testing topic", () => {
+    const topics = detectAvailableTopics(tmpBase, makeCodemap());
+    expect(topics).toContain("testing");
+  });
+
+  it("detects ci topic", () => {
+    const topics = detectAvailableTopics(tmpBase, makeCodemap());
+    expect(topics).toContain("ci");
+  });
+
+  it("deduplicates topics", () => {
+    const topics = detectAvailableTopics(tmpBase, makeCodemap());
+    const unique = [...new Set(topics)];
+    expect(topics.length).toBe(unique.length);
+  });
+});
+
+describe("generateTour", () => {
+  it("generates tour steps for a directory topic", () => {
+    const dir = join(tmpBase, "tour-dir");
+    mkdirSync(join(dir, "src", "auth"), { recursive: true });
+    writeFileSync(join(dir, "src", "auth", "middleware.ts"), "export {}");
+    writeFileSync(join(dir, "src", "auth", "handler.ts"), "export {}");
+
+    const codemap = makeCodemap();
+    const tour = generateTour(dir, "src", codemap);
+    expect(tour.topic).toBe("src");
+    expect(tour.steps.length).toBeGreaterThan(0);
+  });
+
+  it("generates tour for testing topic", () => {
+    const dir = join(tmpBase, "tour-test");
+    mkdirSync(join(dir, "tests"), { recursive: true });
+    writeFileSync(join(dir, "tests", "auth.test.ts"), "");
+
+    const tour = generateTour(dir, "testing", makeCodemap());
+    expect(tour.steps.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatTourMarkdown", () => {
+  it("formats tour with numbered steps", () => {
+    const tour = {
+      projectId: "abc",
+      topic: "auth",
+      generatedAt: "2026-01-01T00:00:00Z",
+      steps: [
+        { file: "src/auth/middleware.ts", description: "Middleware: middleware" },
+        { file: "src/auth/handler.ts", description: "Handler: handler" },
+      ],
+    };
+    const md = formatTourMarkdown(tour);
+    expect(md).toContain("## Code Tour: auth");
+    expect(md).toContain("**1.**");
+    expect(md).toContain("**2.**");
+    expect(md).toContain("middleware.ts");
+  });
+
+  it("handles empty tour", () => {
+    const tour = { projectId: "abc", topic: "empty", generatedAt: "", steps: [] };
+    const md = formatTourMarkdown(tour);
+    expect(md).toContain("No files found");
+  });
+});

--- a/packages/pi-compass/src/tour-generator.ts
+++ b/packages/pi-compass/src/tour-generator.ts
@@ -1,0 +1,237 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import type { CodeMap, CodeTour, TourStep, CacheEntry } from "./types.js";
+import { loadCachedTour, saveCachedTour } from "./storage.js";
+
+const TEST_INDICATORS = ["test", "tests", "spec", "__tests__", "e2e"];
+const CI_INDICATORS = [".github", ".gitlab-ci.yml", "Jenkinsfile"];
+const DB_INDICATORS = ["migrations", "prisma", "drizzle", "alembic", "db", "database"];
+
+export function detectAvailableTopics(
+  _cwd: string,
+  codemap: CodeMap,
+): readonly string[] {
+  const topics: string[] = [];
+
+  for (const entry of codemap.directoryTree) {
+    if (entry.type === "dir" && entry.name !== "node_modules" && entry.name !== "dist") {
+      topics.push(entry.name);
+    }
+  }
+
+  const allNames = codemap.directoryTree.map((e) => e.name.toLowerCase());
+  const keyFilePaths = codemap.keyFiles.map((k) => k.path.toLowerCase());
+
+  if (TEST_INDICATORS.some((t) => allNames.includes(t))) {
+    topics.push("testing");
+  }
+  if (CI_INDICATORS.some((c) => allNames.includes(c) || keyFilePaths.some((k) => k.includes(c)))) {
+    topics.push("ci");
+  }
+  if (DB_INDICATORS.some((d) => allNames.includes(d))) {
+    topics.push("database");
+  }
+
+  return [...new Set(topics)];
+}
+
+export function generateTour(
+  cwd: string,
+  topic: string,
+  codemap: CodeMap,
+): CodeTour {
+  const steps = buildTourSteps(cwd, topic);
+
+  return {
+    projectId: codemap.projectId,
+    topic,
+    generatedAt: new Date().toISOString(),
+    steps,
+  };
+}
+
+function buildTourSteps(
+  cwd: string,
+  topic: string,
+): TourStep[] {
+  const steps: TourStep[] = [];
+
+  const topicDir = join(cwd, topic);
+  const srcTopicDir = join(cwd, "src", topic);
+
+  const dir = safeIsDir(topicDir) ? topicDir : safeIsDir(srcTopicDir) ? srcTopicDir : null;
+
+  if (dir) {
+    const files = collectFiles(dir, cwd, 3);
+    for (const file of files.slice(0, 15)) {
+      steps.push({
+        file,
+        description: describeFile(file),
+      });
+    }
+  }
+
+  if (topic === "testing") {
+    steps.push(...findTestFiles(cwd));
+  } else if (topic === "ci") {
+    steps.push(...findCiFiles(cwd));
+  }
+
+  return steps;
+}
+
+function collectFiles(dir: string, root: string, depth: number): string[] {
+  if (depth <= 0) return [];
+  const results: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  for (const name of entries.sort()) {
+    if (name.startsWith(".")) continue;
+    const full = join(dir, name);
+    const rel = full.slice(root.length + 1);
+
+    try {
+      const stat = statSync(full);
+      if (stat.isFile() && isSourceFile(name)) {
+        results.push(rel);
+      } else if (stat.isDirectory()) {
+        results.push(...collectFiles(full, root, depth - 1));
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return results;
+}
+
+function findTestFiles(cwd: string): TourStep[] {
+  const steps: TourStep[] = [];
+  for (const dir of TEST_INDICATORS) {
+    const full = join(cwd, dir);
+    if (safeIsDir(full)) {
+      const files = collectFiles(full, cwd, 2);
+      for (const file of files.slice(0, 5)) {
+        steps.push({ file, description: describeFile(file) });
+      }
+    }
+  }
+  return steps;
+}
+
+function findCiFiles(cwd: string): TourStep[] {
+  const steps: TourStep[] = [];
+  const workflowDir = join(cwd, ".github", "workflows");
+  if (safeIsDir(workflowDir)) {
+    try {
+      for (const name of readdirSync(workflowDir)) {
+        steps.push({
+          file: `.github/workflows/${name}`,
+          description: `CI workflow: ${name}`,
+        });
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const file of [".gitlab-ci.yml", "Jenkinsfile"]) {
+    if (safeExists(join(cwd, file))) {
+      steps.push({ file, description: `CI configuration: ${file}` });
+    }
+  }
+
+  return steps;
+}
+
+function describeFile(filePath: string): string {
+  const parts = filePath.split("/");
+  const fileName = parts[parts.length - 1] ?? filePath;
+  const ext = extname(fileName);
+  const baseName = fileName.replace(ext, "");
+
+  if (fileName.includes("test") || fileName.includes("spec")) {
+    return `Test file for ${baseName.replace(/[._-]?(test|spec)/, "")}`;
+  }
+  if (fileName === "index.ts" || fileName === "index.js") {
+    const parent = parts[parts.length - 2];
+    return parent ? `Entry point for ${parent} module` : "Package entry point";
+  }
+  if (fileName.includes("config")) return `Configuration: ${baseName}`;
+  if (fileName.includes("route") || fileName.includes("router")) return `Routing: ${baseName}`;
+  if (fileName.includes("middleware")) return `Middleware: ${baseName}`;
+  if (fileName.includes("model") || fileName.includes("schema")) return `Data model: ${baseName}`;
+  if (fileName.includes("service")) return `Service: ${baseName}`;
+  if (fileName.includes("controller") || fileName.includes("handler")) return `Handler: ${baseName}`;
+  if (fileName.includes("util") || fileName.includes("helper")) return `Utility: ${baseName}`;
+
+  return `${baseName} module`;
+}
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java",
+  ".rb", ".php", ".ex", ".exs", ".kt", ".swift", ".c", ".cpp",
+  ".h", ".yml", ".yaml", ".toml", ".json",
+]);
+
+function isSourceFile(name: string): boolean {
+  return SOURCE_EXTENSIONS.has(extname(name));
+}
+
+function safeIsDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function safeExists(path: string): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function formatTourMarkdown(tour: CodeTour): string {
+  if (tour.steps.length === 0) {
+    return `No files found for topic "${tour.topic}".`;
+  }
+
+  const lines = [`## Code Tour: ${tour.topic}`, ""];
+  for (let i = 0; i < tour.steps.length; i++) {
+    const step = tour.steps[i]!;
+    lines.push(`**${i + 1}.** \`${step.file}\``);
+    lines.push(`   ${step.description}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+export function getOrGenerateTour(
+  cwd: string,
+  topic: string,
+  codemap: CodeMap,
+  projectId: string,
+  baseDir?: string,
+): CodeTour {
+  const cached = loadCachedTour(projectId, topic, baseDir);
+  if (cached) return cached.data;
+
+  const tour = generateTour(cwd, topic, codemap);
+  const entry: CacheEntry<CodeTour> = {
+    data: tour,
+    contentHash: codemap.contentHash,
+    createdAt: tour.generatedAt,
+  };
+  saveCachedTour(projectId, topic, entry, baseDir);
+  return tour;
+}

--- a/packages/pi-compass/src/types.ts
+++ b/packages/pi-compass/src/types.ts
@@ -1,0 +1,104 @@
+export interface ProjectInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly root: string;
+  readonly remote: string;
+}
+
+export interface DirectoryEntry {
+  readonly name: string;
+  readonly type: "file" | "dir";
+  readonly children?: readonly DirectoryEntry[];
+}
+
+export type PackageManager = "npm" | "cargo" | "go" | "pip" | "poetry" | "gradle" | "maven" | "composer" | "bundler" | "mix";
+
+export interface PackageInfo {
+  readonly manager: PackageManager;
+  readonly name: string;
+  readonly version?: string;
+  readonly dependencies: readonly string[];
+}
+
+export interface FrameworkDetection {
+  readonly name: string;
+  readonly version?: string;
+  readonly confidence: "definite" | "likely";
+  readonly source: string;
+}
+
+export type EntryPointKind = "main" | "index" | "route" | "handler" | "config";
+
+export interface EntryPoint {
+  readonly path: string;
+  readonly kind: EntryPointKind;
+}
+
+export interface BuildScript {
+  readonly name: string;
+  readonly command: string;
+  readonly source: string;
+}
+
+export interface Convention {
+  readonly source: string;
+  readonly content: string;
+}
+
+export interface KeyFile {
+  readonly path: string;
+  readonly description: string;
+}
+
+export interface CodeMap {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly generatedAt: string;
+  readonly contentHash: string;
+  readonly directoryTree: readonly DirectoryEntry[];
+  readonly packages: readonly PackageInfo[];
+  readonly frameworks: readonly FrameworkDetection[];
+  readonly entryPoints: readonly EntryPoint[];
+  readonly buildScripts: readonly BuildScript[];
+  readonly conventions: readonly Convention[];
+  readonly keyFiles: readonly KeyFile[];
+}
+
+export interface TourStep {
+  readonly file: string;
+  readonly startLine?: number;
+  readonly endLine?: number;
+  readonly description: string;
+}
+
+export interface CodeTour {
+  readonly projectId: string;
+  readonly topic: string;
+  readonly generatedAt: string;
+  readonly steps: readonly TourStep[];
+}
+
+export interface CacheEntry<T> {
+  readonly data: T;
+  readonly contentHash: string;
+  readonly createdAt: string;
+}
+
+export interface CompassConfig {
+  readonly max_injection_chars: number;
+  readonly inject_on_first_turn: boolean;
+  readonly cache_enabled: boolean;
+}
+
+export interface StateRef {
+  get: () => CompassState;
+  set: (s: CompassState) => void;
+}
+
+export interface CompassState {
+  readonly project: ProjectInfo | null;
+  readonly turnCount: number;
+  readonly codemapInjected: boolean;
+  readonly cachedCodemap: CacheEntry<CodeMap> | null;
+  readonly stale: boolean;
+}

--- a/packages/pi-compass/tsconfig.build.json
+++ b/packages/pi-compass/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pi-compass/tsconfig.json
+++ b/packages/pi-compass/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/pi-compass/vitest.config.ts
+++ b/packages/pi-compass/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      thresholds: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    },
+  },
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
   ],
   "packages": {
     "packages/pi-continuous-learning": {},
-    "packages/pi-red-green": {}
+    "packages/pi-red-green": {},
+    "packages/pi-compass": {}
   }
 }


### PR DESCRIPTION
## Summary

New `pi-compass` extension: codebase navigation for Pi coding agent sessions.

- **`/onboard`**: Generates a structured codemap covering directory structure, packages, frameworks, entry points, build scripts, conventions, and key files. Cached per project with content-hash invalidation.
- **`/tour`**: Interactive code tours. `/tour` lists available topics (detected from directory structure), `/tour <topic>` walks through relevant files.
- **LLM tools**: `codebase_map` and `code_tour` for on-demand access from the agent.
- **System prompt injection**: Cached codemap injected on first turn of each session so the agent starts oriented.
- All analysis is deterministic (no LLM calls). 7 analyzers parse config files, directory listings, and package manifests.
- 106 tests across 17 test files, 80% coverage thresholds.
- Release-please, root README, and AGENTS.md updated per checklist.

## Test plan

- [x] `npm run check` passes at root (all 3 workspaces: 1091 tests)
- [x] 106 pi-compass tests passing, clean lint, clean typecheck
- [ ] Manual test: install in a project, run `/onboard`, verify codemap output
- [ ] Manual test: run `/tour`, verify topic listing and walkthrough

Closes #84
