### PR TITLE
feat: add pi-simplify code review extension

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/pi-continuous-learning": "0.13.2",
   "packages/pi-red-green": "0.2.1",
-  "packages/pi-compass": "0.2.0"
+  "packages/pi-compass": "0.2.0",
+  "packages/pi-simplify": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ packages/
   pi-compass/               # Pi extension: codebase navigation (codemap + code tours)
     src/                    # TypeScript source + tests (*.test.ts alongside source)
     CHANGELOG.md            # Release history (managed by release-please)
+  pi-simplify/              # Pi extension: code simplification (/simplify command)
+    src/                    # TypeScript source + tests (*.test.ts alongside source)
+    CHANGELOG.md            # Release history (managed by release-please)
 ```
 
 ## Commands (run from repo root)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A monorepo of [Pi](https://github.com/nicholasgasior/pi-coding-agent) extensions
 | [pi-continuous-learning](packages/pi-continuous-learning) | Observes coding sessions and distils patterns into reusable instincts with confidence scoring and closed-loop feedback | [![npm](https://img.shields.io/npm/v/pi-continuous-learning)](https://www.npmjs.com/package/pi-continuous-learning) |
 | [pi-red-green](packages/pi-red-green) | TDD enforcement for agent sessions: RED-GREEN-REFACTOR state machine with phase-specific prompt injection and test run detection | [![npm](https://img.shields.io/npm/v/pi-red-green)](https://www.npmjs.com/package/pi-red-green) |
 | [pi-compass](packages/pi-compass) | Codebase navigation: generates structured codemaps and interactive code tours for faster agent onboarding | [![npm](https://img.shields.io/npm/v/pi-compass)](https://www.npmjs.com/package/pi-compass) |
+| [pi-simplify](packages/pi-simplify) | Code simplification: reviews recently changed files for clarity, consistency, and maintainability | [![npm](https://img.shields.io/npm/v/pi-simplify)](https://www.npmjs.com/package/pi-simplify) |
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4035,6 +4035,10 @@
       "resolved": "packages/pi-red-green",
       "link": true
     },
+    "node_modules/pi-simplify": {
+      "resolved": "packages/pi-simplify",
+      "link": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -5049,6 +5053,27 @@
     },
     "packages/pi-red-green": {
       "version": "0.2.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-coding-agent": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.62.0",
+        "@sinclair/typebox": "^0.34.0"
+      }
+    },
+    "packages/pi-simplify": {
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/packages/pi-simplify/README.md
+++ b/packages/pi-simplify/README.md
@@ -1,0 +1,50 @@
+# pi-simplify
+
+A [Pi](https://github.com/nicholasgasior/pi-coding-agent) extension that reviews recently changed code for clarity, consistency, and maintainability improvements.
+
+## Installation
+
+```bash
+pi install npm:pi-simplify
+```
+
+## Usage
+
+### Review all uncommitted changes
+
+```
+/simplify
+```
+
+### Review only staged changes
+
+```
+/simplify --staged
+```
+
+### Review specific files
+
+```
+/simplify src/foo.ts src/bar.ts
+```
+
+### Diff against a specific branch
+
+```
+/simplify --ref=main
+```
+
+## What it does
+
+When invoked, `/simplify` detects changed files (via `git diff`) and instructs the agent to review them with these principles:
+
+- **Preserve functionality**: never change what the code does
+- **Apply project standards**: follow conventions from CLAUDE.md / AGENTS.md
+- **Enhance clarity**: reduce complexity, eliminate redundancy, improve naming
+- **Maintain balance**: avoid over-simplification
+
+The agent reads each file, applies improvements one at a time, runs tests to verify nothing breaks, and summarizes the changes.
+
+## License
+
+MIT

--- a/packages/pi-simplify/package.json
+++ b/packages/pi-simplify/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "pi-simplify",
+  "version": "0.1.0",
+  "description": "A Pi extension that reviews recently changed code for clarity, consistency, and maintainability.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Matt Devy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MattDevy/pi-extensions.git",
+    "directory": "packages/pi-simplify"
+  },
+  "homepage": "https://github.com/MattDevy/pi-extensions/tree/main/packages/pi-simplify#readme",
+  "bugs": {
+    "url": "https://github.com/MattDevy/pi-extensions/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "code-review",
+    "simplify",
+    "refactor",
+    "ai",
+    "llm",
+    "ai-agent",
+    "coding-assistant",
+    "developer-tools"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**/*.test.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "scripts": {
+    "clean": "rm -rf dist tsconfig.build.tsbuildinfo",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "check": "vitest run && eslint src/ && tsc --noEmit",
+    "prepublishOnly": "npm run build && npm run check",
+    "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.62.0",
+    "@mariozechner/pi-ai": "^0.62.0",
+    "@mariozechner/pi-tui": "^0.62.0",
+    "@sinclair/typebox": "^0.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/pi-simplify/src/git-diff.test.ts
+++ b/packages/pi-simplify/src/git-diff.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { getChangedFiles } from "./git-diff.js";
+import type { SimplifyOptions } from "./types.js";
+
+function makePi(execResults: Record<string, { stdout: string; stderr: string; code: number }>) {
+  return {
+    exec: vi.fn((_cmd: string, args: string[]) => {
+      const key = args.join(" ");
+      for (const [pattern, result] of Object.entries(execResults)) {
+        if (key.includes(pattern)) return Promise.resolve(result);
+      }
+      return Promise.resolve({ stdout: "", stderr: "", code: 1 });
+    }),
+  } as unknown as Parameters<typeof getChangedFiles>[0];
+}
+
+const defaultOptions: SimplifyOptions = { files: [], ref: "HEAD", staged: false };
+
+describe("getChangedFiles", () => {
+  it("parses modified, added, renamed, and copied lines", async () => {
+    const pi = makePi({
+      "diff --name-status HEAD": {
+        stdout: "M\tsrc/foo.ts\nA\tsrc/bar.ts\nR100\tsrc/old.ts\tsrc/new.ts\nC100\tsrc/a.ts\tsrc/b.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const files = await getChangedFiles(pi, "/project", defaultOptions);
+
+    expect(files).toEqual([
+      { path: "src/foo.ts", status: "modified" },
+      { path: "src/bar.ts", status: "added" },
+      { path: "src/new.ts", status: "renamed" },
+      { path: "src/b.ts", status: "copied" },
+    ]);
+  });
+
+  it("filters out deleted files", async () => {
+    const pi = makePi({
+      "diff --name-status HEAD": {
+        stdout: "M\tsrc/keep.ts\nD\tsrc/gone.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const files = await getChangedFiles(pi, "/project", defaultOptions);
+
+    expect(files).toEqual([{ path: "src/keep.ts", status: "modified" }]);
+  });
+
+  it("falls back to HEAD~1 when HEAD diff is empty", async () => {
+    const pi = makePi({
+      "diff --name-status HEAD~1": {
+        stdout: "M\tsrc/recent.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const files = await getChangedFiles(pi, "/project", defaultOptions);
+
+    expect(files).toEqual([{ path: "src/recent.ts", status: "modified" }]);
+  });
+
+  it("returns empty array when both HEAD and HEAD~1 diffs are empty", async () => {
+    const pi = makePi({});
+
+    const files = await getChangedFiles(pi, "/project", defaultOptions);
+
+    expect(files).toEqual([]);
+  });
+
+  it("uses --cached when staged option is true", async () => {
+    const pi = makePi({
+      "diff --name-status --cached": {
+        stdout: "M\tsrc/staged.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const options: SimplifyOptions = { files: [], ref: "HEAD", staged: true };
+    const files = await getChangedFiles(pi, "/project", options);
+
+    expect(files).toEqual([{ path: "src/staged.ts", status: "modified" }]);
+    expect(pi.exec).toHaveBeenCalledWith(
+      "git",
+      ["diff", "--name-status", "--cached"],
+      { cwd: "/project" },
+    );
+  });
+
+  it("uses custom ref when provided", async () => {
+    const pi = makePi({
+      "diff --name-status main": {
+        stdout: "A\tsrc/feature.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const options: SimplifyOptions = { files: [], ref: "main", staged: false };
+    const files = await getChangedFiles(pi, "/project", options);
+
+    expect(files).toEqual([{ path: "src/feature.ts", status: "added" }]);
+  });
+
+  it("returns explicit file list directly without running git", async () => {
+    const pi = makePi({});
+
+    const options: SimplifyOptions = {
+      files: ["src/a.ts", "src/b.ts"],
+      ref: "HEAD",
+      staged: false,
+    };
+    const files = await getChangedFiles(pi, "/project", options);
+
+    expect(files).toEqual([
+      { path: "src/a.ts", status: "modified" },
+      { path: "src/b.ts", status: "modified" },
+    ]);
+    expect(pi.exec).not.toHaveBeenCalled();
+  });
+
+  it("handles blank lines in git output", async () => {
+    const pi = makePi({
+      "diff --name-status HEAD": {
+        stdout: "M\tsrc/foo.ts\n\n\nA\tsrc/bar.ts\n",
+        stderr: "",
+        code: 0,
+      },
+    });
+
+    const files = await getChangedFiles(pi, "/project", defaultOptions);
+
+    expect(files).toEqual([
+      { path: "src/foo.ts", status: "modified" },
+      { path: "src/bar.ts", status: "added" },
+    ]);
+  });
+});

--- a/packages/pi-simplify/src/git-diff.ts
+++ b/packages/pi-simplify/src/git-diff.ts
@@ -1,0 +1,63 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ChangedFile, SimplifyOptions } from "./types.js";
+
+const STATUS_MAP: Record<string, ChangedFile["status"]> = {
+  M: "modified",
+  A: "added",
+  R: "renamed",
+  C: "copied",
+};
+
+function parseDiffOutput(stdout: string): ChangedFile[] {
+  const files: ChangedFile[] = [];
+
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+
+    const parts = line.split("\t");
+    const statusCode = parts[0]?.[0];
+    if (!statusCode) continue;
+
+    const status = STATUS_MAP[statusCode];
+    if (!status) continue;
+
+    // Renamed (R100\told\tnew) and copied (C100\told\tnew) have two paths; use the new one.
+    const path = (status === "renamed" || status === "copied") ? parts[2] : parts[1];
+    if (path) {
+      files.push({ path, status });
+    }
+  }
+
+  return files;
+}
+
+export async function getChangedFiles(
+  pi: ExtensionAPI,
+  cwd: string,
+  options: SimplifyOptions,
+): Promise<ChangedFile[]> {
+  if (options.files.length > 0) {
+    return options.files.map((path) => ({ path, status: "modified" as const }));
+  }
+
+  const args = ["diff", "--name-status"];
+  if (options.staged) {
+    args.push("--cached");
+  } else {
+    args.push(options.ref);
+  }
+
+  const result = await pi.exec("git", args, { cwd });
+  if (result.code === 0) {
+    const files = parseDiffOutput(result.stdout);
+    if (files.length > 0) return files;
+  }
+
+  // Fallback: diff against previous commit
+  const fallback = await pi.exec("git", ["diff", "--name-status", "HEAD~1"], { cwd });
+  if (fallback.code === 0) {
+    return parseDiffOutput(fallback.stdout);
+  }
+
+  return [];
+}

--- a/packages/pi-simplify/src/index.test.ts
+++ b/packages/pi-simplify/src/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import registerExtension from "./index.js";
+
+describe("pi-simplify extension", () => {
+  it("registers the simplify command", () => {
+    const pi = {
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+    } as unknown as Parameters<typeof registerExtension>[0];
+
+    registerExtension(pi);
+
+    expect(pi.registerCommand).toHaveBeenCalledOnce();
+    expect(pi.registerCommand).toHaveBeenCalledWith(
+      "simplify",
+      expect.objectContaining({
+        description: expect.any(String),
+        handler: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not register any event handlers", () => {
+    const pi = {
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+    } as unknown as Parameters<typeof registerExtension>[0];
+
+    registerExtension(pi);
+
+    expect(pi.on).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pi-simplify/src/index.ts
+++ b/packages/pi-simplify/src/index.ts
@@ -1,0 +1,14 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { handleSimplifyCommand, COMMAND_NAME } from "./simplify-command.js";
+
+export default function (pi: ExtensionAPI): void {
+  pi.registerCommand(COMMAND_NAME, {
+    description:
+      "Review recently changed files for clarity, consistency, and maintainability improvements",
+    handler: (args: string, ctx: ExtensionCommandContext) =>
+      handleSimplifyCommand(args, ctx, pi),
+  });
+}

--- a/packages/pi-simplify/src/prompt-builder.test.ts
+++ b/packages/pi-simplify/src/prompt-builder.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildSimplifyPrompt } from "./prompt-builder.js";
+import type { ChangedFile } from "./types.js";
+
+describe("buildSimplifyPrompt", () => {
+  const files: readonly ChangedFile[] = [
+    { path: "src/foo.ts", status: "modified" },
+    { path: "src/bar.ts", status: "added" },
+  ];
+
+  it("lists all file paths in the prompt", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toContain("src/foo.ts");
+    expect(prompt).toContain("src/bar.ts");
+  });
+
+  it("includes preserve-functionality principle", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/preserve.*functionality/i);
+  });
+
+  it("includes clarity principle", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/clarity/i);
+  });
+
+  it("includes balance principle", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/over-simplif/i);
+  });
+
+  it("includes project standards reference", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/CLAUDE\.md|AGENTS\.md/);
+  });
+
+  it("includes instruction to run tests", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/test/i);
+  });
+
+  it("works with a single file", () => {
+    const prompt = buildSimplifyPrompt([{ path: "src/only.ts", status: "modified" }]);
+
+    expect(prompt).toContain("src/only.ts");
+  });
+
+  it("includes scope restriction", () => {
+    const prompt = buildSimplifyPrompt(files);
+
+    expect(prompt).toMatch(/only.*review|do not.*outside/i);
+  });
+});

--- a/packages/pi-simplify/src/prompt-builder.ts
+++ b/packages/pi-simplify/src/prompt-builder.ts
@@ -1,0 +1,29 @@
+import type { ChangedFile } from "./types.js";
+
+export function buildSimplifyPrompt(files: readonly ChangedFile[]): string {
+  const fileList = files.map((f) => `- ${f.path} (${f.status})`).join("\n");
+
+  return `Review the following recently changed files and apply simplification improvements.
+
+## Principles
+
+- **Preserve functionality**: Never change what the code does. All existing tests must continue to pass.
+- **Apply project standards**: Follow any conventions from CLAUDE.md or AGENTS.md in this project.
+- **Enhance clarity**: Reduce unnecessary complexity and nesting, eliminate redundant code and abstractions, improve variable and function names, consolidate related logic, remove unnecessary comments that describe obvious code. Avoid nested ternary operators: prefer switch statements or if/else chains for multiple conditions.
+- **Maintain balance**: Do not over-simplify. Avoid overly clever solutions that are hard to understand. Do not combine too many concerns into single functions. Do not remove helpful abstractions. Prioritize readability over fewer lines.
+
+## Scope
+
+Only review and modify these files:
+${fileList}
+
+## Process
+
+1. Read each file listed above
+2. Identify concrete improvements (dead code, unclear names, redundant logic, inconsistent patterns)
+3. Apply changes one file at a time
+4. After all changes, run existing tests to verify nothing is broken
+5. Summarize what you changed and why
+
+Do NOT add new features, change public APIs, or refactor code outside the listed files.`;
+}

--- a/packages/pi-simplify/src/simplify-command.test.ts
+++ b/packages/pi-simplify/src/simplify-command.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleSimplifyCommand, parseArgs, COMMAND_NAME } from "./simplify-command.js";
+
+describe("COMMAND_NAME", () => {
+  it("is 'simplify'", () => {
+    expect(COMMAND_NAME).toBe("simplify");
+  });
+});
+
+describe("parseArgs", () => {
+  it("returns defaults for empty string", () => {
+    expect(parseArgs("")).toEqual({ files: [], ref: "HEAD", staged: false });
+  });
+
+  it("returns defaults for whitespace-only string", () => {
+    expect(parseArgs("   ")).toEqual({ files: [], ref: "HEAD", staged: false });
+  });
+
+  it("parses --staged flag", () => {
+    expect(parseArgs("--staged")).toEqual({ files: [], ref: "HEAD", staged: true });
+  });
+
+  it("parses --ref=<value> flag", () => {
+    expect(parseArgs("--ref=main")).toEqual({ files: [], ref: "main", staged: false });
+  });
+
+  it("parses file paths", () => {
+    expect(parseArgs("src/a.ts src/b.ts")).toEqual({
+      files: ["src/a.ts", "src/b.ts"],
+      ref: "HEAD",
+      staged: false,
+    });
+  });
+
+  it("parses mix of flags and file paths", () => {
+    expect(parseArgs("--staged src/a.ts")).toEqual({
+      files: ["src/a.ts"],
+      ref: "HEAD",
+      staged: true,
+    });
+  });
+
+  it("parses --ref with file paths", () => {
+    expect(parseArgs("--ref=develop src/foo.ts")).toEqual({
+      files: ["src/foo.ts"],
+      ref: "develop",
+      staged: false,
+    });
+  });
+});
+
+describe("handleSimplifyCommand", () => {
+  function makeMocks(changedFiles: string[]) {
+    const execResults: Record<string, { stdout: string; stderr: string; code: number }> = {};
+
+    if (changedFiles.length > 0) {
+      const stdout = changedFiles.map((f) => `M\t${f}`).join("\n") + "\n";
+      execResults["diff --name-status HEAD"] = { stdout, stderr: "", code: 0 };
+    }
+
+    const pi = {
+      exec: vi.fn((_cmd: string, args: string[]) => {
+        const key = args.join(" ");
+        for (const [pattern, result] of Object.entries(execResults)) {
+          if (key.includes(pattern)) return Promise.resolve(result);
+        }
+        return Promise.resolve({ stdout: "", stderr: "", code: 1 });
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as Parameters<typeof handleSimplifyCommand>[2];
+
+    const ctx = {
+      cwd: "/project",
+      ui: {
+        notify: vi.fn(),
+      },
+    } as unknown as Parameters<typeof handleSimplifyCommand>[1];
+
+    return { pi, ctx };
+  }
+
+  it("sends user message when changed files are found", async () => {
+    const { pi, ctx } = makeMocks(["src/foo.ts"]);
+
+    await handleSimplifyCommand("", ctx, pi);
+
+    expect(pi.sendUserMessage).toHaveBeenCalledOnce();
+    const prompt = (pi.sendUserMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(prompt).toContain("src/foo.ts");
+    expect(pi.sendUserMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      { deliverAs: "followUp" },
+    );
+  });
+
+  it("notifies user when no changed files found", async () => {
+    const { pi, ctx } = makeMocks([]);
+
+    await handleSimplifyCommand("", ctx, pi);
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("No changed files"),
+      "info",
+    );
+  });
+
+  it("uses explicit file paths from args", async () => {
+    const { pi, ctx } = makeMocks([]);
+
+    await handleSimplifyCommand("src/a.ts src/b.ts", ctx, pi);
+
+    expect(pi.exec).not.toHaveBeenCalled();
+    expect(pi.sendUserMessage).toHaveBeenCalledOnce();
+    const prompt = (pi.sendUserMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(prompt).toContain("src/a.ts");
+    expect(prompt).toContain("src/b.ts");
+  });
+
+  it("passes --staged to git diff", async () => {
+    const pi = {
+      exec: vi.fn(() => Promise.resolve({
+        stdout: "M\tsrc/staged.ts\n",
+        stderr: "",
+        code: 0,
+      })),
+      sendUserMessage: vi.fn(),
+    } as unknown as Parameters<typeof handleSimplifyCommand>[2];
+
+    const ctx = {
+      cwd: "/project",
+      ui: { notify: vi.fn() },
+    } as unknown as Parameters<typeof handleSimplifyCommand>[1];
+
+    await handleSimplifyCommand("--staged", ctx, pi);
+
+    expect(pi.exec).toHaveBeenCalledWith(
+      "git",
+      ["diff", "--name-status", "--cached"],
+      { cwd: "/project" },
+    );
+  });
+});

--- a/packages/pi-simplify/src/simplify-command.ts
+++ b/packages/pi-simplify/src/simplify-command.ts
@@ -1,0 +1,48 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { getChangedFiles } from "./git-diff.js";
+import { buildSimplifyPrompt } from "./prompt-builder.js";
+import type { SimplifyOptions } from "./types.js";
+
+export const COMMAND_NAME = "simplify";
+
+export function parseArgs(args: string): SimplifyOptions {
+  const tokens = args.trim().split(/\s+/).filter(Boolean);
+  const files: string[] = [];
+  let ref = "HEAD";
+  let staged = false;
+
+  for (const token of tokens) {
+    if (token === "--staged") {
+      staged = true;
+    } else if (token.startsWith("--ref=")) {
+      ref = token.slice("--ref=".length);
+    } else {
+      files.push(token);
+    }
+  }
+
+  return { files, ref, staged };
+}
+
+export async function handleSimplifyCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const options = parseArgs(args);
+  const files = await getChangedFiles(pi, ctx.cwd, options);
+
+  if (files.length === 0) {
+    ctx.ui.notify(
+      "No changed files found. Specify file paths or make some changes first.",
+      "info",
+    );
+    return;
+  }
+
+  const prompt = buildSimplifyPrompt(files);
+  pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+}

--- a/packages/pi-simplify/src/types.ts
+++ b/packages/pi-simplify/src/types.ts
@@ -1,0 +1,10 @@
+export interface ChangedFile {
+  readonly path: string;
+  readonly status: "modified" | "added" | "renamed" | "copied";
+}
+
+export interface SimplifyOptions {
+  readonly files: readonly string[];
+  readonly ref: string;
+  readonly staged: boolean;
+}

--- a/packages/pi-simplify/tsconfig.build.json
+++ b/packages/pi-simplify/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pi-simplify/tsconfig.json
+++ b/packages/pi-simplify/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/pi-simplify/vitest.config.ts
+++ b/packages/pi-simplify/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      thresholds: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    },
+  },
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
   "packages": {
     "packages/pi-continuous-learning": {},
     "packages/pi-red-green": {},
-    "packages/pi-compass": {}
+    "packages/pi-compass": {},
+    "packages/pi-simplify": {}
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "files": [],
   "references": [
-    { "path": "packages/pi-continuous-learning" }
+    { "path": "packages/pi-continuous-learning" },
+    { "path": "packages/pi-red-green" },
+    { "path": "packages/pi-compass" },
+    { "path": "packages/pi-simplify" }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `pi-simplify`, a new Pi extension that ports Claude Code's `/simplify` command
- Registers `/simplify` command that detects changed files via `git diff` and sends a structured prompt instructing the agent to review for clarity, consistency, and maintainability
- Supports `--staged`, `--ref=<branch>`, and explicit file path arguments
- 30 tests, typecheck/lint/build all pass

## Test plan

- [ ] `npm run check` passes (tests + lint + typecheck)
- [ ] `npm run build -w packages/pi-simplify` compiles successfully
- [ ] Install in Pi session via `pi install npm:pi-simplify` and run `/simplify` after making changes
- [ ] Verify `/simplify --staged` only picks up staged files
- [ ] Verify `/simplify src/foo.ts` targets specific files
