### PR TITLE
fix(deps): correct dependabot grouping for monorepo dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,26 +13,17 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     groups:
-      # Group all production dependencies together
-      production-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "@types/*"
-          - "eslint*"
-          - "prettier"
-        update-types:
-          - "minor"
-          - "patch"
-
-      # Separate group for dev dependencies
       development-dependencies:
         patterns:
           - "@types/*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
           - "eslint*"
           - "prettier"
-          - "jest"
+          - "vitest*"
           - "typescript"
+          - "globals"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

- Replaces the misleading `production-dependencies` catch-all group (which had no actual production deps to catch) with a single, explicit `development-dependencies` group
- Adds `@eslint/*`, `@typescript-eslint/*`, `vitest*`, and `globals` to the group — these were previously falling into the wrong bucket via the `*` wildcard
- Removes `jest` (not used in this repo — we use vitest)
- Adds `dependency-type: "development"` for clean, explicit semantics rather than relying on pattern-based exclusions

## Test plan

- [ ] Verify the next Dependabot run batches `@types/*`, `@typescript-eslint/*`, `@eslint/*`, `vitest*`, `typescript`, `globals`, `eslint`, and `prettier` minor/patch bumps into a single `development-dependencies` PR
- [ ] Confirm major version bumps (e.g. a future typescript 7.x) still arrive as individual ungrouped PRs