### PR TITLE
chore(deps): migrate pi-blueprint to @earendil-works namespace

### DIFF
--- a/packages/pi-blueprint/package.json
+++ b/packages/pi-blueprint/package.json
@@ -56,9 +56,9 @@
     "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.62.0",
-    "@mariozechner/pi-ai": "^0.62.0",
-    "@mariozechner/pi-tui": "^0.62.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/pi-blueprint/src/blueprint-command.test.ts
+++ b/packages/pi-blueprint/src/blueprint-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handleBlueprintCommand } from "./blueprint-command.js";
 import type { StateRef, BlueprintExtensionState, Blueprint, Phase, Task } from "./types.js";
 

--- a/packages/pi-blueprint/src/blueprint-command.ts
+++ b/packages/pi-blueprint/src/blueprint-command.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { StateRef } from "./types.js";
 import { renderPlanMarkdown } from "./plan-renderer.js";
 import { getBlueprintGeneratePrompt } from "./prompts/blueprint-generate.js";

--- a/packages/pi-blueprint/src/blueprint-tools.test.ts
+++ b/packages/pi-blueprint/src/blueprint-tools.test.ts
@@ -76,7 +76,7 @@ describe("registerBlueprintTools", () => {
       get: () => state,
       set: (s) => { state = s; },
     };
-    registerBlueprintTools(pi as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI, stateRef);
+    registerBlueprintTools(pi as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI, stateRef);
   });
 
   it("registers 4 tools", () => {

--- a/packages/pi-blueprint/src/blueprint-tools.ts
+++ b/packages/pi-blueprint/src/blueprint-tools.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { StateRef, Phase, Task, VerificationGate } from "./types.js";
 import {

--- a/packages/pi-blueprint/src/index.test.ts
+++ b/packages/pi-blueprint/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import registerExtension from "./index.js";
 import { registerBlueprintTools } from "./blueprint-tools.js";
 

--- a/packages/pi-blueprint/src/index.ts
+++ b/packages/pi-blueprint/src/index.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { BlueprintExtensionState } from "./types.js";
 import {
   ensureBaseDir,

--- a/packages/pi-blueprint/src/plan-next-command.test.ts
+++ b/packages/pi-blueprint/src/plan-next-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handlePlanNextCommand } from "./plan-next-command.js";
 import type { StateRef, BlueprintExtensionState, Phase, Task } from "./types.js";
 

--- a/packages/pi-blueprint/src/plan-next-command.ts
+++ b/packages/pi-blueprint/src/plan-next-command.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { StateRef } from "./types.js";
 import { getNextTask } from "./state-machine.js";
 

--- a/packages/pi-blueprint/src/plan-status-command.test.ts
+++ b/packages/pi-blueprint/src/plan-status-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handlePlanStatusCommand } from "./plan-status-command.js";
 import type { StateRef, BlueprintExtensionState, Phase, Task } from "./types.js";
 

--- a/packages/pi-blueprint/src/plan-status-command.ts
+++ b/packages/pi-blueprint/src/plan-status-command.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { StateRef } from "./types.js";
 import { isTaskDone } from "./types.js";
 import { renderPlanMarkdown } from "./plan-renderer.js";

--- a/packages/pi-blueprint/src/plan-verify-command.test.ts
+++ b/packages/pi-blueprint/src/plan-verify-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handlePlanVerifyCommand } from "./plan-verify-command.js";
 import type { StateRef, BlueprintExtensionState, Phase, Task, VerificationGate } from "./types.js";
 

--- a/packages/pi-blueprint/src/plan-verify-command.ts
+++ b/packages/pi-blueprint/src/plan-verify-command.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { StateRef } from "./types.js";
 import { verifyGate, advancePhase } from "./state-machine.js";
 import { runGate } from "./verification.js";


### PR DESCRIPTION
\`npm install -g pi-blueprint\` emits four \`@mariozechner\` deprecation warnings on every install. The \`@earendil-works/pi-*\` packages at v0.74.0 are the canonical replacements.

## Scope (pi-blueprint only)

This PR migrates only \`packages/pi-blueprint\`. All 12 source and test files under \`src/\` and the workspace \`package.json\` were updated — a namespace-only change.

The other workspaces are being migrated in separate PRs (see #102 for pi-simplify).

## Verification

- \`npm --workspace=pi-blueprint run typecheck\`: clean.
- \`npm --workspace=pi-blueprint test\`: 103 of 103 vitest tests pass.

## Note on Conventional Commits

This is a \`chore(deps)\` change. The migrated workspace keeps its existing public API; only its peer dependency names change.

BEGIN_COMMIT_OVERRIDE
fix(deps): migrate to @earendil-works namespace
END_COMMIT_OVERRIDE