### PR TITLE
chore(deps): migrate pi-compass to @earendil-works namespace

### DIFF
--- a/packages/pi-compass/package.json
+++ b/packages/pi-compass/package.json
@@ -55,9 +55,9 @@
     "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.62.0",
-    "@mariozechner/pi-ai": "^0.62.0",
-    "@mariozechner/pi-tui": "^0.62.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/pi-compass/src/index.test.ts
+++ b/packages/pi-compass/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import extension from "./index.js";
 
 function makeMockPi(): ExtensionAPI {

--- a/packages/pi-compass/src/index.ts
+++ b/packages/pi-compass/src/index.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 import { detectProject } from "./project.js";
 import { ensureStorageLayout, loadCachedCodemap } from "./storage.js";

--- a/packages/pi-compass/src/onboard-command.test.ts
+++ b/packages/pi-compass/src/onboard-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterAll } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handleOnboardCommand } from "./onboard-command.js";
 import type { StateRef } from "./types.js";
 import type { CompassState } from "./types.js";

--- a/packages/pi-compass/src/onboard-command.ts
+++ b/packages/pi-compass/src/onboard-command.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { generateCodemap } from "./codemap-generator.js";
 import { formatCodemapMarkdown } from "./codemap-formatter.js";
 import { saveCachedCodemap } from "./storage.js";

--- a/packages/pi-compass/src/onboard-tools.test.ts
+++ b/packages/pi-compass/src/onboard-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterAll } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerOnboardTools } from "./onboard-tools.js";
 import type { StateRef } from "./types.js";
 import type { CompassState, CodeMap, CacheEntry } from "./types.js";

--- a/packages/pi-compass/src/onboard-tools.ts
+++ b/packages/pi-compass/src/onboard-tools.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { StateRef } from "./types.js";
 import { getOrGenerateCodemap } from "./codemap-generator.js";

--- a/packages/pi-compass/src/project.test.ts
+++ b/packages/pi-compass/src/project.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { detectProject } from "./project.js";
 
 function makeMockPi(execResults: Record<string, { code: number; stdout: string; stderr: string }>): ExtensionAPI {

--- a/packages/pi-compass/src/project.ts
+++ b/packages/pi-compass/src/project.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { basename } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ProjectInfo } from "./types.js";
 
 function hashString(input: string): string {

--- a/packages/pi-compass/src/tour-command.test.ts
+++ b/packages/pi-compass/src/tour-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterAll } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { handleTourCommand } from "./tour-command.js";
 import type { StateRef } from "./types.js";
 import type { CompassState, CodeMap, CacheEntry } from "./types.js";

--- a/packages/pi-compass/src/tour-command.ts
+++ b/packages/pi-compass/src/tour-command.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { detectAvailableTopics, getOrGenerateTour, formatTourMarkdown } from "./tour-generator.js";
 import type { StateRef } from "./types.js";
 import { getOrGenerateCodemap } from "./codemap-generator.js";


### PR DESCRIPTION
\`npm install -g pi-compass\` emits four \`@mariozechner\` deprecation warnings on every install. The \`@earendil-works/pi-*\` packages at v0.74.0 are the canonical replacements.

## Scope (pi-compass only)

This PR migrates only \`packages/pi-compass\`. All 10 source and test files under \`src/\` and the workspace \`package.json\` were updated — a namespace-only change.

The other workspaces are being migrated in separate PRs (see #102 for pi-simplify).

## Verification

- \`npm --workspace=pi-compass run typecheck\`: clean.
- \`npm --workspace=pi-compass test\`: 106 of 106 vitest tests pass.

## Note on Conventional Commits

This is a \`chore(deps)\` change. The migrated workspace keeps its existing public API; only its peer dependency names change.

BEGIN_COMMIT_OVERRIDE
fix(deps): migrate to @earendil-works namespace
END_COMMIT_OVERRIDE