### PR TITLE
chore(deps): migrate pi-code-review to @earendil-works namespace

### DIFF
--- a/packages/pi-code-review/package.json
+++ b/packages/pi-code-review/package.json
@@ -53,9 +53,9 @@
     "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.62.0",
-    "@mariozechner/pi-ai": "^0.62.0",
-    "@mariozechner/pi-tui": "^0.62.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/pi-code-review/src/index.ts
+++ b/packages/pi-code-review/src/index.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { createEditTracker } from "./edit-tracker.js";
 import {
   handleBeforeAgentStart,

--- a/packages/pi-code-review/src/review-command.ts
+++ b/packages/pi-code-review/src/review-command.ts
@@ -1,8 +1,8 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
-import { complete, getModel } from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-coding-agent";
+import { complete, getModel } from "@earendil-works/pi-ai";
 import { detectLanguage } from "./language-detector.js";
 import { buildReviewPrompt, buildFallbackPrompt } from "./review-prompt.js";
 import { parseReviewFindings, formatFindings } from "./review-parser.js";


### PR DESCRIPTION
\`npm install -g pi-code-review\` emits four \`@mariozechner\` deprecation warnings on every install. The \`@earendil-works/pi-*\` packages at v0.74.0 are the canonical replacements.

## Scope (pi-code-review only)

This PR migrates only \`packages/pi-code-review\`. Files touched: \`src/index.ts\`, \`src/review-command.ts\` (which imports both \`@earendil-works/pi-coding-agent\` and \`@earendil-works/pi-ai\`), and the workspace \`package.json\`.

The other workspaces are being migrated in separate PRs (see #102 for pi-simplify).

## Verification

- \`npm --workspace=pi-code-review run typecheck\`: clean.
- \`npm --workspace=pi-code-review test\`: 70 of 70 vitest tests pass.

## Note on Conventional Commits

This is a \`chore(deps)\` change. The migrated workspace keeps its existing public API; only its peer dependency names change.

BEGIN_COMMIT_OVERRIDE
fix(deps): migrate to @earendil-works namespace
END_COMMIT_OVERRIDE