### PR TITLE
chore(deps): migrate pi-continuous-learning to @earendil-works namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5805,9 +5805,9 @@
         "@rollup/rollup-linux-x64-gnu": "4.60.3"
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "^0.62.0",
-        "@mariozechner/pi-coding-agent": "^0.62.0",
-        "@mariozechner/pi-tui": "^0.62.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
         "@sinclair/typebox": "^0.34.0"
       }
     },

--- a/packages/pi-continuous-learning/package.json
+++ b/packages/pi-continuous-learning/package.json
@@ -61,9 +61,9 @@
     "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.62.0",
-    "@mariozechner/pi-ai": "^0.62.0",
-    "@mariozechner/pi-tui": "^0.62.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/pi-continuous-learning/src/analysis-notification.test.ts
+++ b/packages/pi-continuous-learning/src/analysis-notification.test.ts
@@ -10,7 +10,7 @@ import {
   appendAnalysisEvent,
   type AnalysisEvent,
 } from "./analysis-event-log.js";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,6 +38,11 @@ function makeMockCtx(): ExtensionContext {
       onTerminalInput: vi.fn(),
       setStatus: vi.fn(),
       setWorkingMessage: vi.fn(),
+      setWorkingVisible: vi.fn(),
+      setWorkingIndicator: vi.fn(),
+      setHiddenThinkingLabel: vi.fn(),
+      addAutocompleteProvider: vi.fn(),
+      getEditorComponent: vi.fn(),
       setWidget: vi.fn(),
       setFooter: vi.fn(),
       setHeader: vi.fn(),
@@ -63,6 +68,7 @@ function makeMockCtx(): ExtensionContext {
     modelRegistry: {} as unknown as ExtensionContext["modelRegistry"],
     model: undefined,
     isIdle: vi.fn(),
+    signal: undefined,
     abort: vi.fn(),
     hasPendingMessages: vi.fn(),
     shutdown: vi.fn(),

--- a/packages/pi-continuous-learning/src/analysis-notification.ts
+++ b/packages/pi-continuous-learning/src/analysis-notification.ts
@@ -6,7 +6,7 @@
  * last session interaction.
  */
 
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   consumeAnalysisEvents,
   type AnalysisEvent,

--- a/packages/pi-continuous-learning/src/cli/analyze-model.ts
+++ b/packages/pi-continuous-learning/src/cli/analyze-model.ts
@@ -1,11 +1,11 @@
-import type { AuthStorage } from "@mariozechner/pi-coding-agent";
+import type { AuthStorage } from "@earendil-works/pi-coding-agent";
 import {
   getModel,
   getProviders,
   type Api,
   type KnownProvider,
   type Model,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import type { Config } from "../types.js";
 
 type AnalyzerAuthStorage = Pick<AuthStorage, "getApiKey">;

--- a/packages/pi-continuous-learning/src/cli/analyze-single-shot.ts
+++ b/packages/pi-continuous-learning/src/cli/analyze-single-shot.ts
@@ -5,8 +5,8 @@
  * The model receives all current instincts inline and returns a JSON change-set.
  * Changes are applied client-side, eliminating the ~16x cache-read multiplier.
  */
-import type { AssistantMessage, Context } from "@mariozechner/pi-ai";
-import { complete } from "@mariozechner/pi-ai";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
+import { complete } from "@earendil-works/pi-ai";
 import type { Instinct } from "../types.js";
 import { serializeInstinct } from "../instinct-parser.js";
 

--- a/packages/pi-continuous-learning/src/cli/analyze.ts
+++ b/packages/pi-continuous-learning/src/cli/analyze.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import { AuthStorage } from "@mariozechner/pi-coding-agent";
+import { AuthStorage } from "@earendil-works/pi-coding-agent";
 
 import { loadConfig, DEFAULT_CONFIG } from "../config.js";
 import type { InstalledSkill, ProjectEntry } from "../types.js";
@@ -325,8 +325,8 @@ async function analyzeProject(
 
   let installedSkills: InstalledSkill[] = [];
   try {
-    const { loadSkills } = await import("@mariozechner/pi-coding-agent");
-    const result = loadSkills({ cwd: project.root });
+    const { loadSkills, getAgentDir } = await import("@earendil-works/pi-coding-agent");
+    const result = loadSkills({ cwd: project.root, agentDir: getAgentDir(), skillPaths: [], includeDefaults: true });
     installedSkills = result.skills.map(
       (s: { name: string; description: string }) => ({
         name: s.name,
@@ -645,8 +645,8 @@ async function consolidateProject(
 
   let installedSkills: InstalledSkill[] = [];
   try {
-    const { loadSkills } = await import("@mariozechner/pi-coding-agent");
-    const result = loadSkills({ cwd: project.root });
+    const { loadSkills, getAgentDir } = await import("@earendil-works/pi-coding-agent");
+    const result = loadSkills({ cwd: project.root, agentDir: getAgentDir(), skillPaths: [], includeDefaults: true });
     installedSkills = result.skills.map(
       (s: { name: string; description: string }) => ({
         name: s.name,

--- a/packages/pi-continuous-learning/src/fact-tools.ts
+++ b/packages/pi-continuous-learning/src/fact-tools.ts
@@ -1,6 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type, type Static } from "@sinclair/typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type, type Static, StringEnum } from "@earendil-works/pi-ai";
 import { unlinkSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { Fact } from "./types.js";

--- a/packages/pi-continuous-learning/src/index.test.ts
+++ b/packages/pi-continuous-learning/src/index.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { COMMAND_NAME as STATUS_CMD } from "./instinct-status.js";
 import { COMMAND_NAME as EXPORT_CMD } from "./instinct-export.js";
 import { COMMAND_NAME as IMPORT_CMD } from "./instinct-import.js";

--- a/packages/pi-continuous-learning/src/index.ts
+++ b/packages/pi-continuous-learning/src/index.ts
@@ -9,8 +9,8 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
-import { loadSkills } from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
+import { loadSkills, getAgentDir } from "@earendil-works/pi-coding-agent";
 
 import { loadConfig } from "./config.js";
 import { detectProject } from "./project.js";
@@ -80,7 +80,7 @@ export default function (pi: ExtensionAPI): void {
       cleanOldArchives(project.id);
 
       try {
-        const result = loadSkills({ cwd: ctx.cwd });
+        const result = loadSkills({ cwd: ctx.cwd, agentDir: getAgentDir(), skillPaths: [], includeDefaults: true });
         installedSkills = result.skills.map((s) => ({
           name: s.name,
           description: s.description,

--- a/packages/pi-continuous-learning/src/instinct-dream.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-dream.test.ts
@@ -9,7 +9,7 @@ import { saveInstinct } from "./instinct-store.js";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 let tmpDir: string;
 

--- a/packages/pi-continuous-learning/src/instinct-dream.ts
+++ b/packages/pi-continuous-learning/src/instinct-dream.ts
@@ -9,7 +9,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { InstalledSkill } from "./types.js";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/packages/pi-continuous-learning/src/instinct-evolve.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-evolve.test.ts
@@ -9,7 +9,7 @@ import { saveInstinct } from "./instinct-store.js";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 let tmpDir: string;
 

--- a/packages/pi-continuous-learning/src/instinct-evolve.ts
+++ b/packages/pi-continuous-learning/src/instinct-evolve.ts
@@ -1,7 +1,7 @@
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { InstalledSkill } from "./types.js";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/packages/pi-continuous-learning/src/instinct-export.ts
+++ b/packages/pi-continuous-learning/src/instinct-export.ts
@@ -6,7 +6,7 @@
 
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { Instinct, InstinctScope } from "./types.js";
 import { loadProjectInstincts, loadGlobalInstincts } from "./instinct-store.js";
 

--- a/packages/pi-continuous-learning/src/instinct-graduate.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-graduate.test.ts
@@ -27,7 +27,7 @@ import type {
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/pi-continuous-learning/src/instinct-graduate.ts
+++ b/packages/pi-continuous-learning/src/instinct-graduate.ts
@@ -13,7 +13,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { Instinct } from "./types.js";
 import {
   getBaseDir,

--- a/packages/pi-continuous-learning/src/instinct-import.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-import.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./instinct-import.js";
 import { ensureStorageLayout } from "./storage.js";
 import { saveInstinct } from "./instinct-store.js";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/pi-continuous-learning/src/instinct-import.ts
+++ b/packages/pi-continuous-learning/src/instinct-import.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { Instinct } from "./types.js";
 import { saveInstinct, listInstincts } from "./instinct-store.js";
 import {

--- a/packages/pi-continuous-learning/src/instinct-injector.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-injector.test.ts
@@ -15,7 +15,7 @@ import {
   clearActiveInstincts,
 } from "./active-instincts.js";
 import type { Instinct, Config } from "./types.js";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type {
   BeforeAgentStartEvent,
   AgentEndEvent,

--- a/packages/pi-continuous-learning/src/instinct-injector.ts
+++ b/packages/pi-continuous-learning/src/instinct-injector.ts
@@ -5,7 +5,7 @@
  * Also bridges injected instinct IDs to shared active-instincts state (US-023).
  */
 
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type {
   BeforeAgentStartEvent,
   AgentEndEvent,

--- a/packages/pi-continuous-learning/src/instinct-projects.ts
+++ b/packages/pi-continuous-learning/src/instinct-projects.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { ProjectEntry } from "./types.js";
 import {
   getProjectsRegistryPath,

--- a/packages/pi-continuous-learning/src/instinct-promote.test.ts
+++ b/packages/pi-continuous-learning/src/instinct-promote.test.ts
@@ -28,7 +28,7 @@ import {
   autoPromoteInstincts,
   handleInstinctPromote,
 } from "./instinct-promote.js";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/pi-continuous-learning/src/instinct-promote.ts
+++ b/packages/pi-continuous-learning/src/instinct-promote.ts
@@ -8,7 +8,7 @@
  */
 
 import { mkdirSync } from "node:fs";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { Instinct } from "./types.js";
 import {
   loadProjectInstincts,

--- a/packages/pi-continuous-learning/src/instinct-status.ts
+++ b/packages/pi-continuous-learning/src/instinct-status.ts
@@ -4,7 +4,7 @@
  * trend arrows, and feedback ratios.
  */
 
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { Instinct, Fact } from "./types.js";
 import { loadProjectInstincts, loadGlobalInstincts } from "./instinct-store.js";
 import { loadProjectFacts, loadGlobalFacts } from "./fact-store.js";

--- a/packages/pi-continuous-learning/src/instinct-tools.ts
+++ b/packages/pi-continuous-learning/src/instinct-tools.ts
@@ -1,6 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type, type Static } from "@sinclair/typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type, type Static, StringEnum } from "@earendil-works/pi-ai";
 import { unlinkSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { Instinct } from "./types.js";

--- a/packages/pi-continuous-learning/src/project.test.ts
+++ b/packages/pi-continuous-learning/src/project.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { createHash } from "node:crypto";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { detectProject } from "./project.js";
 
 function makeHash(input: string): string {

--- a/packages/pi-continuous-learning/src/project.ts
+++ b/packages/pi-continuous-learning/src/project.ts
@@ -5,7 +5,7 @@
 
 import { createHash } from "node:crypto";
 import { basename } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ProjectEntry } from "./types.js";
 
 const GLOBAL_PROJECT_ID = "global";

--- a/packages/pi-continuous-learning/src/prompt-observer.test.ts
+++ b/packages/pi-continuous-learning/src/prompt-observer.test.ts
@@ -37,7 +37,7 @@ function makeCtx(sessionId = "test-session-014") {
       contextWindow: 200000,
       percent: 0.5,
     }),
-  } as unknown as import("@mariozechner/pi-coding-agent").ExtensionContext;
+  } as unknown as import("@earendil-works/pi-coding-agent").ExtensionContext;
 }
 
 function makePromptEvent(prompt: string): BeforeAgentStartEvent {

--- a/packages/pi-continuous-learning/src/prompt-observer.ts
+++ b/packages/pi-continuous-learning/src/prompt-observer.ts
@@ -3,7 +3,7 @@
  * Captures before_agent_start (user_prompt) and agent_end events as JSONL observations.
  */
 
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 // Local event type definitions (not all pi-coding-agent versions re-export these at top level)
 export interface BeforeAgentStartEvent {

--- a/packages/pi-continuous-learning/src/session-observer.test.ts
+++ b/packages/pi-continuous-learning/src/session-observer.test.ts
@@ -39,7 +39,7 @@ function makeCtx(sessionId = "test-session-020") {
       contextWindow: 200000,
       percent: 2.5,
     }),
-  } as unknown as import("@mariozechner/pi-coding-agent").ExtensionContext;
+  } as unknown as import("@earendil-works/pi-coding-agent").ExtensionContext;
 }
 
 function readObservations(

--- a/packages/pi-continuous-learning/src/session-observer.ts
+++ b/packages/pi-continuous-learning/src/session-observer.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import { getCurrentActiveInstincts } from "./active-instincts.js";
 import { appendObservation } from "./observations.js";

--- a/packages/pi-continuous-learning/src/tool-observer.test.ts
+++ b/packages/pi-continuous-learning/src/tool-observer.test.ts
@@ -34,7 +34,7 @@ function makeCtx(sessionId = "test-session-001") {
     sessionManager: {
       getSessionId: () => sessionId,
     },
-  } as unknown as import("@mariozechner/pi-coding-agent").ExtensionContext;
+  } as unknown as import("@earendil-works/pi-coding-agent").ExtensionContext;
 }
 
 function makeStartEvent(

--- a/packages/pi-continuous-learning/src/tool-observer.ts
+++ b/packages/pi-continuous-learning/src/tool-observer.ts
@@ -3,7 +3,7 @@
  * Captures tool_execution_start and tool_execution_end events as JSONL observations.
  */
 
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 // Local event type definitions (not all pi-coding-agent versions re-export these at top level)
 export interface ToolExecutionStartEvent {


### PR DESCRIPTION
## Summary

Migrates `packages/pi-continuous-learning` from the deprecated `@mariozechner/*@^0.62.0` packages to `@earendil-works/*@^0.74.0`, mirroring what PR #102 did for `pi-simplify`.

- Updates `peerDependencies` in `package.json` to `@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` at `^0.74.0`
- Replaces all `@mariozechner/*` import specifiers across 32 source and test files
- Fixes all type errors arising from API shape changes between versions

## API shape changes fixed

### `loadSkills` — new required options
`loadSkills` now requires `agentDir`, `skillPaths`, and `includeDefaults` in addition to `cwd`. Updated all three call sites:
- `src/index.ts` (session_start hook)
- Two dynamic `import()` calls in `src/cli/analyze.ts`

All now pass `getAgentDir()`, `[]`, and `true` for the new fields.

### `ExtensionUIContext` — new required methods
The `ExtensionUIContext` interface gained five new required methods between 0.62 and 0.74: `setWorkingVisible`, `setWorkingIndicator`, `setHiddenThinkingLabel`, `addAutocompleteProvider`, and `getEditorComponent`. Added these as `vi.fn()` stubs to the test mock in `src/analysis-notification.test.ts`.

### `ExtensionContext` — new `signal` property
`ExtensionContext` now declares `signal: AbortSignal | undefined`. Added to the test mock alongside the existing fields.

### TypeBox / `StringEnum` compatibility
`@earendil-works/pi-ai` now re-exports `Type` and `Static` from `typebox@^1.1.x` (not `@sinclair/typebox@0.34`). The `StringEnum` helper it exports returns `TUnsafe<T>` which extends `TSchema` from `typebox@1.x` — but is structurally incompatible with `@sinclair/typebox@0.34`'s `TSchema`.

Fixed in `fact-tools.ts` and `instinct-tools.ts` by switching all three imports (`Type`, `Static`, `StringEnum`) from `@sinclair/typebox` / `@earendil-works/pi-ai` to importing everything from `@earendil-works/pi-ai` (which re-exports the compatible v1 `Type` and `Static`).

## Test plan
- [x] `npm run typecheck -w packages/pi-continuous-learning` — 0 errors
- [x] `npm run test -w packages/pi-continuous-learning` — 839 tests pass across 52 test files

BEGIN_COMMIT_OVERRIDE
fix(deps): migrate to @earendil-works namespace
END_COMMIT_OVERRIDE