### PR TITLE
fix(pi-simplify): widen peer ranges to allow 0.75.x

### DIFF
--- a/packages/pi-simplify/package.json
+++ b/packages/pi-simplify/package.json
@@ -55,9 +55,9 @@
     "prepack": "test -d dist || { echo 'Error: dist/ missing. Run npm run build first.' && exit 1; }"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.76.0",
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Widen the `@earendil-works/pi-{ai,coding-agent,tui}` peer ranges in `packages/pi-simplify/package.json` from `^0.74.0` to `>=0.74.0 <0.76.0`.

The current `^0.74.0` ceiling (`<0.75.0`) prevents installing any extension that peers `^0.75.x` (e.g. `pi-rtk-optimizer@0.8.0`) alongside `pi-simplify`. npm resolves the intersection to `0.74.x` for pi-simplify's constraint, then the newer extension's `^0.75.4` peer is unsatisfiable, and `pi update` fails with `ERESOLVE`.

Pi runtime itself shipped 0.75 weeks ago and `pi -v` already reports `0.75.x` on current installs, so widening the range realigns the peer with the runtime already deployed.

Widening to `>=0.74.0 <0.76.0` (caret-OR equivalent: `^0.74.0 || ^0.75.0`) keeps existing 0.74.x users working while unblocking the 0.75 line.

Note: this is the same kind of fix being requested over at https://github.com/nicobailon/pi-powerline-footer/issues/67 — pi-simplify hits the exact same downstream conflict.

Scoped to `pi-simplify` only; happy to do the equivalent change across the other packages in this monorepo if you want — just say the word and I'll send follow-up PRs.

## Test plan

- [ ] After release, run `pi install npm:pi-rtk-optimizer` on a host that already has `pi-simplify` installed — should resolve cleanly without `--legacy-peer-deps`
- [ ] `pi update` should succeed on a host with the current extension set
- [ ] Existing CI for pi-simplify continues to pass (no code change, peer range only)