### PR TITLE
fix(pi-compass): keep codemaps scoped and fresh

### DIFF
--- a/packages/pi-compass/src/codemap-generator.test.ts
+++ b/packages/pi-compass/src/codemap-generator.test.ts
@@ -86,15 +86,20 @@ describe("getOrGenerateCodemap", () => {
     expect(result.stale).toBe(false);
   });
 
-  it("detects stale cache when content changes", () => {
+  it("regenerates stale cache when content changes", () => {
     const cacheDir = join(tmpBase, "cache-stale");
     ensureStorageLayout("gen-stale", cacheDir);
     const dir = setupProject("get-stale", { "package.json": '{"name":"z"}' });
-    getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
+    const initial = getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
 
     writeFileSync(join(dir, "package.json"), '{"name":"z","version":"2.0.0"}');
-    const result = getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
-    expect(result.fromCache).toBe(true);
-    expect(result.stale).toBe(true);
+    const refreshed = getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
+    expect(refreshed.fromCache).toBe(false);
+    expect(refreshed.stale).toBe(false);
+    expect(refreshed.codemap.contentHash).not.toBe(initial.codemap.contentHash);
+
+    const cached = getOrGenerateCodemap(dir, "gen-stale", "z", cacheDir);
+    expect(cached.fromCache).toBe(true);
+    expect(cached.codemap.contentHash).toBe(refreshed.codemap.contentHash);
   });
 });

--- a/packages/pi-compass/src/codemap-generator.ts
+++ b/packages/pi-compass/src/codemap-generator.ts
@@ -91,12 +91,8 @@ export function getOrGenerateCodemap(
   baseDir?: string,
 ): CodemapResult {
   const cached = loadCachedCodemap(projectId, baseDir);
-  if (cached) {
-    const currentHash = computeContentHash(cwd);
-    if (cached.contentHash === currentHash) {
-      return { codemap: cached.data, fromCache: true, stale: false };
-    }
-    return { codemap: cached.data, fromCache: true, stale: true };
+  if (cached && cached.contentHash === computeContentHash(cwd)) {
+    return { codemap: cached.data, fromCache: true, stale: false };
   }
 
   const codemap = generateCodemap(cwd, projectId, projectName);

--- a/packages/pi-compass/src/index.ts
+++ b/packages/pi-compass/src/index.ts
@@ -5,7 +5,7 @@ import type {
 
 import { detectProject } from "./project.js";
 import { ensureStorageLayout, loadCachedCodemap } from "./storage.js";
-import { computeContentHash } from "./codemap-generator.js";
+import { getOrGenerateCodemap } from "./codemap-generator.js";
 import {
   handleBeforeAgentStart as buildInjection,
   type BeforeAgentStartEvent,
@@ -37,13 +37,18 @@ export default function (pi: ExtensionAPI): void {
       ensureStorageLayout(project.id);
 
       const cached = loadCachedCodemap(project.id);
-      let stale = false;
-      if (cached) {
-        const currentHash = computeContentHash(project.root);
-        stale = cached.contentHash !== currentHash;
-      }
+      const codemap = cached
+        ? getOrGenerateCodemap(project.root, project.id, project.name).codemap
+        : null;
+      const cachedCodemap = codemap
+        ? {
+            data: codemap,
+            contentHash: codemap.contentHash,
+            createdAt: codemap.generatedAt,
+          }
+        : null;
 
-      state = { ...state, project, cachedCodemap: cached, stale };
+      state = { ...state, project, cachedCodemap, stale: false };
 
       registerOnboardTools(pi, stateRef);
     } catch (err) {

--- a/packages/pi-compass/src/onboard-tools.ts
+++ b/packages/pi-compass/src/onboard-tools.ts
@@ -37,6 +37,15 @@ function createCodemapTool(stateRef: StateRef) {
         state.project.id,
         state.project.name,
       );
+      stateRef.set({
+        ...state,
+        cachedCodemap: {
+          data: codemap,
+          contentHash: codemap.contentHash,
+          createdAt: codemap.generatedAt,
+        },
+        stale: false,
+      });
 
       const markdown = formatCodemapMarkdown(codemap);
       return {
@@ -66,8 +75,20 @@ function createTourTool(stateRef: StateRef) {
         throw new Error("No project detected.");
       }
 
-      const codemap = state.cachedCodemap?.data
-        ?? getOrGenerateCodemap(state.project.root, state.project.id, state.project.name).codemap;
+      const { codemap } = getOrGenerateCodemap(
+        state.project.root,
+        state.project.id,
+        state.project.name,
+      );
+      stateRef.set({
+        ...state,
+        cachedCodemap: {
+          data: codemap,
+          contentHash: codemap.contentHash,
+          createdAt: codemap.generatedAt,
+        },
+        stale: false,
+      });
 
       if (!params.topic) {
         const topics = detectAvailableTopics(state.project.root, codemap);

--- a/packages/pi-compass/src/project.test.ts
+++ b/packages/pi-compass/src/project.test.ts
@@ -1,6 +1,12 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
 import { describe, it, expect, vi } from "vitest";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { detectProject } from "./project.js";
+
+function hashString(input: string): string {
+  return createHash("sha256").update(input).digest("hex").substring(0, 12);
+}
 
 function makeMockPi(execResults: Record<string, { code: number; stdout: string; stderr: string }>): ExtensionAPI {
   return {
@@ -12,14 +18,15 @@ function makeMockPi(execResults: Record<string, { code: number; stdout: string; 
 }
 
 describe("detectProject", () => {
-  it("uses git remote URL when available", async () => {
+  it("uses the git root and remote URL when invoked from a subdirectory", async () => {
     const pi = makeMockPi({
+      "git rev-parse --show-toplevel": { code: 0, stdout: "/home/user/repo\n", stderr: "" },
       "git remote get-url origin": { code: 0, stdout: "https://github.com/user/repo.git\n", stderr: "" },
     });
-    const project = await detectProject(pi, "/home/user/repo");
+    const project = await detectProject(pi, "/home/user/repo/packages/app");
     expect(project.name).toBe("repo");
     expect(project.remote).toBe("https://github.com/user/repo.git");
-    expect(project.id).toHaveLength(12);
+    expect(project.id).toBe(hashString("https://github.com/user/repo.git"));
     expect(project.root).toBe("/home/user/repo");
   });
 
@@ -33,15 +40,18 @@ describe("detectProject", () => {
     expect(project.root).toBe("/home/user/repo");
   });
 
-  it("falls back to global when not in a git repo", async () => {
+  it("hashes the absolute cwd when not in a git repo", async () => {
     const pi = makeMockPi({});
     const project = await detectProject(pi, "/tmp/scratch");
-    expect(project.id).toBe("global");
+    expect(project.id).toBe(hashString(resolve("/tmp/scratch")));
+    expect(project.id).not.toBe("global");
     expect(project.name).toBe("scratch");
+    expect(project.root).toBe(resolve("/tmp/scratch"));
   });
 
   it("produces consistent hashes for the same remote", async () => {
     const pi = makeMockPi({
+      "git rev-parse --show-toplevel": { code: 0, stdout: "/home/user/repo\n", stderr: "" },
       "git remote get-url origin": { code: 0, stdout: "https://github.com/user/repo.git\n", stderr: "" },
     });
     const p1 = await detectProject(pi, "/home/user/repo");

--- a/packages/pi-compass/src/project.ts
+++ b/packages/pi-compass/src/project.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { basename } from "node:path";
+import { basename, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ProjectInfo } from "./types.js";
 
@@ -11,19 +11,20 @@ export async function detectProject(
   pi: ExtensionAPI,
   cwd: string,
 ): Promise<ProjectInfo> {
-  const name = basename(cwd);
-
-  const remoteResult = await pi.exec("git", ["remote", "get-url", "origin"], { cwd });
-  if (remoteResult.code === 0) {
-    const remote = remoteResult.stdout.trim();
-    return { id: hashString(remote), name, root: cwd, remote };
-  }
-
-  const rootResult = await pi.exec("git", ["rev-parse", "--show-toplevel"], { cwd });
+  const absoluteCwd = resolve(cwd);
+  const rootResult = await pi.exec("git", ["rev-parse", "--show-toplevel"], { cwd: absoluteCwd });
   if (rootResult.code === 0) {
     const root = rootResult.stdout.trim();
-    return { id: hashString(root), name, root, remote: "" };
+    const name = basename(root);
+    const remoteResult = await pi.exec("git", ["remote", "get-url", "origin"], { cwd: root });
+    const remote = remoteResult.code === 0 ? remoteResult.stdout.trim() : "";
+    return { id: hashString(remote || root), name, root, remote };
   }
 
-  return { id: "global", name, root: cwd, remote: "" };
+  return {
+    id: hashString(absoluteCwd),
+    name: basename(absoluteCwd),
+    root: absoluteCwd,
+    remote: "",
+  };
 }

--- a/packages/pi-compass/src/tour-generator.test.ts
+++ b/packages/pi-compass/src/tour-generator.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, afterAll } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { detectAvailableTopics, generateTour, formatTourMarkdown } from "./tour-generator.js";
+import {
+  detectAvailableTopics,
+  generateTour,
+  formatTourMarkdown,
+  getOrGenerateTour,
+} from "./tour-generator.js";
+import { ensureStorageLayout, loadCachedTour } from "./storage.js";
 import type { CodeMap } from "./types.js";
 
 const tmpBase = mkdtempSync(join(tmpdir(), "compass-tour-test-"));
@@ -75,6 +81,21 @@ describe("generateTour", () => {
 
     const tour = generateTour(dir, "testing", makeCodemap());
     expect(tour.steps.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getOrGenerateTour", () => {
+  it("regenerates a cached tour when the codemap changes", () => {
+    const dir = join(tmpBase, "tour-cache");
+    const cacheDir = join(tmpBase, "tour-cache-storage");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), "export {}");
+    ensureStorageLayout("abc", cacheDir);
+
+    getOrGenerateTour(dir, "src", makeCodemap({ contentHash: "first" }), "abc", cacheDir);
+    getOrGenerateTour(dir, "src", makeCodemap({ contentHash: "second" }), "abc", cacheDir);
+
+    expect(loadCachedTour("abc", "src", cacheDir)?.contentHash).toBe("second");
   });
 });
 

--- a/packages/pi-compass/src/tour-generator.ts
+++ b/packages/pi-compass/src/tour-generator.ts
@@ -224,7 +224,7 @@ export function getOrGenerateTour(
   baseDir?: string,
 ): CodeTour {
   const cached = loadCachedTour(projectId, topic, baseDir);
-  if (cached) return cached.data;
+  if (cached && cached.contentHash === codemap.contentHash) return cached.data;
 
   const tour = generateTour(cwd, topic, codemap);
   const entry: CacheEntry<CodeTour> = {


### PR DESCRIPTION
## Summary

Fix project detection and cache invalidation in `pi-compass` so codemaps consistently describe the project Pi is currently running in.

- derive non-Git project IDs from a hash of the absolute cwd instead of sharing the `global` cache key
- resolve the Git top-level directory before reading the remote, so sessions started in a repository subdirectory map the repository root
- regenerate and persist stale codemaps instead of returning stale cached data
- invalidate cached code tours when their source codemap hash changes
- refresh the extension's in-memory codemap after `codebase_map` and `code_tour` regenerate it

## Why

Previously, every non-Git directory used `~/.pi/compass/projects/global`. Opening unrelated folders could therefore reuse another folder's codemap.

For Git repositories with a remote, project detection returned the session cwd as the project root. If Pi started in a nested package or subdirectory, `codebase_map` analyzed that directory rather than the repository root even though the cache ID represented the whole repository.

Finally, `getOrGenerateCodemap` detected content changes but returned the stale entry. That meant `codebase_map`, startup injection, and code tours could continue presenting outdated structure until `/onboard --refresh` was run manually.

This PR makes cache identity, analysis root, and cache freshness agree with the current project while preserving the existing behavior of not generating a startup codemap when no cache exists.

## Validation

- Added coverage for Git subdirectory root resolution
- Added coverage for absolute-cwd IDs in non-Git folders
- Updated stale codemap coverage to verify regeneration and persistence
- Added stale code-tour invalidation coverage
- Ran `npm run check` successfully across all workspaces
